### PR TITLE
Prevent excessive logs generation

### DIFF
--- a/src/modules/mainsail/filesystem/root/etc/nginx/sites-available/mainsail
+++ b/src/modules/mainsail/filesystem/root/etc/nginx/sites-available/mainsail
@@ -1,8 +1,8 @@
 server {
     listen 80 default_server;
 
-    access_log /var/log/nginx/mainsail-access.log;
-    error_log /var/log/nginx/mainsail-error.log;
+    error_log syslog:server=unix:/dev/log;
+    access_log syslog:server=unix:/dev/log;
 
     # disable this section on smaller hardware like a pi zero
     gzip on;


### PR DESCRIPTION
Webcam module for example will create 15 requests per second and thus flush of logs, killing almost any SD card in a couple of months. By using systemd logging capability, flushes are rare, and only when errors happen and one can easily check the logs by issuing  `journalctl -f -u nginx`