### PR TITLE
Update moonraker.conf

### DIFF
--- a/src/modules/moonraker/filesystem/home/pi/klipper_config/moonraker.conf
+++ b/src/modules/moonraker/filesystem/home/pi/klipper_config/moonraker.conf
@@ -1,11 +1,16 @@
 [server]
 host: 0.0.0.0
 port: 7125
+# Verbose logging used for debugging . Default False.
 enable_debug_logging: False
+# The maximum size allowed for a file upload (in MiB).  Default 1024 MiB
+max_upload_size: 1024
 
 [file_manager]
 config_path: ~/klipper_config
 log_path: ~/klipper_logs
+# post processing for object cancel. Not recommended for low resource SBCs such as a Pi Zero. Default False 
+enable_object_processing: False
 
 [authorization]
 cors_domains:
@@ -30,6 +35,7 @@ trusted_clients:
 
 # this enables moonraker's update manager
 [update_manager]
+refresh_interval: 168 
 
 [update_manager mainsail]
 type: web


### PR DESCRIPTION
This makes some default values "visible" so that the user finds them without looking in the docs.

It also changes the update refresh to 7 days instead of the 28 days default

Signed-off-by: Alex Zellner alexander.zellner@googlemail.com