### PR TITLE
refactor: updated input shaper dependencies to python3

### DIFF
--- a/src/modules/is_req_preinstall/config
+++ b/src/modules/is_req_preinstall/config
@@ -1,4 +1,4 @@
 [ -n "$IS_REQ_PREINSTALL_VENV_DIR" ] || IS_REQ_PREINSTALL_VENV_DIR=/home/${BASE_USER}/klippy-env
-[ -n "$IS_REQ_PREINSTALL_DEPS" ] || IS_REQ_PREINSTALL_DEPS="python-numpy python-matplotlib"
+[ -n "$IS_REQ_PREINSTALL_DEPS" ] || IS_REQ_PREINSTALL_DEPS="python3-numpy python3-matplotlib"
 [ -n "$IS_REQ_PREINSTALL_PIP" ] || IS_REQ_PREINSTALL_PIP="numpy"
 [ -n "$IS_REQ_PREINSTALL_CFG_FILE" ] || IS_REQ_PREINSTALL_CFG_FILE="/boot/config.txt"

--- a/src/modules/klipper/config
+++ b/src/modules/klipper/config
@@ -4,7 +4,7 @@
 [ -n "$KLIPPER_REPO_SHIP" ] || KLIPPER_REPO_SHIP=https://github.com/Klipper3d/klipper.git
 [ -n "$KLIPPER_REPO_BRANCH" ] || KLIPPER_REPO_BRANCH=master
 [ -n "$KLIPPER_DEPS" ] || KLIPPER_DEPS="wget git gpiod \
-virtualenv python-dev \
+virtualenv python-dev python-matplotlib \
 libffi-dev build-essential \
 libncurses-dev libusb-dev \
 avrdude gcc-avr binutils-avr avr-libc \


### PR DESCRIPTION
Updated Inputshaper Dependencies to python3
python3-numpy, python3-matplotlib

Moved Dependency python-matplotlib to klipper module dependencies

Signed-off-by: Stephan Wendel <me@stephanwe.de>