### PR TITLE
feat: changed logging and logrotate behavior

### DIFF
--- a/src/modules/mainsail/filesystem/root/etc/logrotate.d/rsyslog
+++ b/src/modules/mainsail/filesystem/root/etc/logrotate.d/rsyslog
@@ -1,8 +1,8 @@
 /var/log/syslog
 {
-        rotate 4
+        rotate 2
         daily
-        maxsize 256M
+        maxsize 128M
         missingok
         notifempty
         delaycompress
@@ -25,9 +25,9 @@
 /var/log/debug
 /var/log/messages
 {
-        rotate 4
-        weekly
-        maxsize 256M
+        rotate 2
+        daily
+        maxsize 128M
         missingok
         notifempty
         compress

--- a/src/modules/mainsail/filesystem/root/etc/nginx/sites-available/mainsail
+++ b/src/modules/mainsail/filesystem/root/etc/nginx/sites-available/mainsail
@@ -58,17 +58,25 @@ server {
 
     location /webcam/ {
         proxy_pass http://mjpgstreamer1/;
+        access_log off;
+        error_log off;
     }
 
     location /webcam2/ {
         proxy_pass http://mjpgstreamer2/;
+        access_log off;
+        error_log off;
     }
 
     location /webcam3/ {
+        access_log off;
+        error_log off;
         proxy_pass http://mjpgstreamer3/;
     }
 
     location /webcam4/ {
+        access_log off;
+        error_log off;
         proxy_pass http://mjpgstreamer4/;
     }
 }

--- a/src/modules/mainsail/start_chroot_script
+++ b/src/modules/mainsail/start_chroot_script
@@ -29,6 +29,9 @@ apt update && apt install ${MAINSAIL_DEPS} -y
 rm /etc/nginx/sites-enabled/default
 ln -s /etc/nginx/sites-available/mainsail /etc/nginx/sites-enabled/
 
+# lower nginx rotate cycle to 2 instead 14
+sudo sed -i 's/rotate 14/rotate 2/' /etc/logrotate.d/nginx
+
 ### Download and Install Mainsail Web Frontend
 pushd /home/${BASE_USER}
 sudo -u ${BASE_USER} wget -q --show-progress -O mainsail.zip "${MAINSAIL_URL}"

--- a/src/modules/mjpgstreamer/filesystem/root/etc/logrotate.d/webcamd
+++ b/src/modules/mjpgstreamer/filesystem/root/etc/logrotate.d/webcamd
@@ -1,9 +1,9 @@
-  
+
 /var/log/webcamd.log
 {
-    rotate 4
+    rotate 2
     weekly
-    maxsize 64M
+    maxsize 32M
     missingok
     notifempty
     compress


### PR DESCRIPTION
Disabled logging for 'webcam*' nginx proxy

Changed nginx logrotate 'rotate' from 14 to 2

Changed webcamd logging, rotate 2 and limit to 32M

Changed rsyslog logrotate 'rotate' from 4 to 2
and limit from 256M to 128M and daily instead of weekly

Signed-off-by: Stephan Wendel <me@stephanwe.de>