### PR TITLE
fix(mainsail): changed download url to mainsail-crew url

### DIFF
--- a/src/modules/mainsail/config
+++ b/src/modules/mainsail/config
@@ -1,2 +1,2 @@
 [ -n "$MAINSAIL_DEPS" ] || MAINSAIL_DEPS="nginx"
-[ -n "$MAINSAIL_URL" ] || MAINSAIL_URL=https://github.com/meteyou/mainsail/releases/latest/download/mainsail.zip
+[ -n "$MAINSAIL_URL" ] || MAINSAIL_URL=https://github.com/mainsail-crew/mainsail/releases/latest/download/mainsail.zip


### PR DESCRIPTION
Used https://github.com/meteyou/mainsail instead of
https://github.com/mainsail-crew/mainsail

Signed-off-by: Stephan Wendel <me@stephanwe.de>