### PR TITLE
Update for all boards with two csi ports.

### DIFF
--- a/src/modules/mjpgstreamer/filesystem/root/usr/local/bin/webcamd
+++ b/src/modules/mjpgstreamer/filesystem/root/usr/local/bin/webcamd
@@ -216,7 +216,7 @@ while true; do
   video_devices=($(find /dev -regextype sed -regex '\/dev/video[0-9]\+' | sort -nk1.11 2> /dev/null))
 
   # add list of raspi camera into an array
-  if [ "`vcgencmd get_camera`" = "supported=1 detected=1" ]; then
+  if [ "`vcgencmd get_camera`" = "supported=1 detected=1" ] || [ "`vcgencmd get_camera`" = "supported=2 detected=1" ] || [ "`vcgencmd get_camera`" = "supported=2 detected=2" ]; then
     video_devices+=( "raspi" )
   fi
 


### PR DESCRIPTION
Update for all boards with twi csi ports.
Also mostly for CM4 Modul career board

Actually it seems not the full fix.

- [ ] Working

Output of that script:
```
Starting up webcamDaemon...

--- Configuration: ----------------------------
cfg_file:      /home/pi/klipper_config/webcam.txt
camera:        raspi
usb options:   -r 640x480 -f 10
raspi options: -fps 10
http options:  -w ./www-mjpgstreamer -n

Explicitly USB device: 
-----------------------------------------------

Found video devices:
/dev/video0
/dev/video10
/dev/video11
/dev/video12
/dev/video13
/dev/video14
/dev/video15
/dev/video16
/dev/video18
raspi
config file='/home/pi/klipper_config/webcam.txt':Start MJPG-streamer with video device: raspi
<13>Apr  9 14:45:47 pi: Starting Raspberry Pi camera
Checking for VL805 (Raspberry Pi 4)...
  - It seems that you don't have VL805 (Raspberry Pi 4).
    There should be no problems with USB (a.k.a. select() timeout)
Running ./mjpg_streamer -o output_http.so -w ./www-mjpgstreamer -n -i input_raspicam.so -fps 10
MJPG Streamer Version: git rev: 310b29f4a94c46652b20c4b7b6e5cf24e532af39
 i: fps.............: 10
 i: resolution........: 640 x 480
 i: camera parameters..............:

Sharpness 0, Contrast 0, Brightness 50
Saturation 0, ISO 0, Video Stabilisation No, Exposure compensation 0
Exposure Mode 'auto', AWB Mode 'auto', Image Effect 'none'
Metering Mode 'average', Colour Effect Enabled No with U = 128, V = 128
Rotation 0, hflip No, vflip No
ROI x 0.000000, y 0.000000, w 1.000000 h 1.000000
 o: www-folder-path......: ./www-mjpgstreamer/
 o: HTTP TCP port........: 8080
 o: HTTP Listen Address..: (null)
 o: username:password....: disabled
 o: commands.............: disabled
 i: Starting Camera
Encoder Buffer Size 81920
Done bring up all configured video device

Goodbye...
```