### PR TITLE
feat: stop part fan on CANCEL_PRINT

### DIFF
--- a/src/modules/mainsail/filesystem/home/pi/klipper_config/mainsail.cfg
+++ b/src/modules/mainsail/filesystem/home/pi/klipper_config/mainsail.cfg
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license
 #
-# Version 1.7
+# Version 1.8
 
 # add [include mainsail.cfg] to your printer.cfg to include it to your printer.cfg
 # modify x_park, y_park, z_park_delta and extrude value at the macro _TOOLHEAD_PARK_PAUSE_CANCEL if needed
@@ -28,6 +28,7 @@ gcode:
     _TOOLHEAD_PARK_PAUSE_CANCEL
   {% endif %}
   TURN_OFF_HEATERS
+  M106 S0
   CANCEL_PRINT_BASE
 
 [gcode_macro PAUSE]
@@ -56,7 +57,7 @@ gcode:
     {% if printer.gcode_move.absolute_extrude |lower == 'true' %} M82 {% endif %}
   {% else %}
     {action_respond_info("Extruder not hot enough")}
-  {% endif %}  
+  {% endif %}
   RESUME_BASE {get_params}
 
 [gcode_macro _TOOLHEAD_PARK_PAUSE_CANCEL]


### PR DESCRIPTION
Adds an `M106 S0` command to `CANCEL_PRINT` macro in order to stop the print cooling fan!

(Note: file has also been automatically reformatted with the exiting ".editorconfig" in the repo!)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>