### PR TITLE
refactor(klipper): refactor klipper and is-pre-install module

### DIFF
--- a/src/modules/is_req_preinstall/config
+++ b/src/modules/is_req_preinstall/config
@@ -1,3 +1,5 @@
+#!/bin/bash
+# shellcheck disable=all
 [ -n "$IS_REQ_PREINSTALL_VENV_DIR" ] || IS_REQ_PREINSTALL_VENV_DIR=/home/${BASE_USER}/klippy-env
 [ -n "$IS_REQ_PREINSTALL_DEPS" ] || IS_REQ_PREINSTALL_DEPS="python3-numpy python3-matplotlib"
 [ -n "$IS_REQ_PREINSTALL_PIP" ] || IS_REQ_PREINSTALL_PIP="numpy<=1.21.4"

--- a/src/modules/is_req_preinstall/start_chroot_script
+++ b/src/modules/is_req_preinstall/start_chroot_script
@@ -1,59 +1,61 @@
 #!/usr/bin/env bash
-# 
-# Copyright 2021 by Stephan Wendel aka KwadFan
-# <me@stephanwe.de>
-# This file may distributed under GPLv3
-########
+#### MainsailOS Build Chain
+####
+#### Klipper Install Module
+####
+#### Written by Stephan Wendel aka KwadFan <me@stephanwe.de>
+#### Copyright 2021 - 2022
+#### https://github.com/mainsail-crew/MainsailOS
+####
+#### This File is distributed under GPLv3
+####
 
-### For easier maintainability look to klipper/config.
+# shellcheck enable=require-variable-braces
 
 ## Source error handling, leave this in place
-set -xe
+set -Eex
+
+# Set LC_ALL to prevent errors
+export LC_ALL=C
+
+# Set DEBIAN_FRONTEND to noninteractive
+if [ "${DEBIAN_FRONTEND}" != "noninteractive" ]; then
+    export DEBIAN_FRONTEND=noninteractive
+fi
 
 # Source CustomPIOS common.sh
+# shellcheck disable=SC1091
 source /common.sh
 install_cleanup_trap
 
-echo_green "Input Shaper Requirements preinstall"
+echo_green "Install Input Shaper requirements ..."
 
 ### install all deps at once for time consumption reasons.
 ## APT: Update Repo Database and install Dependencies
-
+# Force apt update
+apt update
 echo_green "Installing Input Shaper Dependencies ..."
-apt update && apt install ${IS_REQ_PREINSTALL_DEPS} -y
-
-### numpy Parallelizing
-function max_cores() {
-    local core_count
-    core_count="$(nproc)"
-    if [ "${core_count}" -lt 3 ]; then
-        echo "$core_count"
-    else
-        echo "$(("${core_count}" -1))"
-    fi
-}
-
-echo_green "System has $(nproc) Cores available."
-echo_green "Using $(max_cores)..."
-export NPY_NUM_BUILD_JOBS="$(max_cores)"
-
+# shellcheck disable=SC2086
+# Disabling shellcheck SC2086, because we want "wordsplitting"
+check_install_pkgs ${IS_REQ_PREINSTALL_DEPS}
 
 ### Check for Klipper Venv installed.
-pushd /home/${BASE_USER}
+pushd "/home/${BASE_USER}" &> /dev/null || exit 1
 if [ -d "${IS_REQ_PREINSTALL_VENV_DIR}" ] && [ -x "${IS_REQ_PREINSTALL_VENV_DIR}/bin/pip" ]; then
     echo_green "Installing numpy..."
-    sudo -u ${BASE_USER} ${IS_REQ_PREINSTALL_VENV_DIR}/bin/pip install -v "${IS_REQ_PREINSTALL_PIP}"
+    sudo -u "${BASE_USER}" "${IS_REQ_PREINSTALL_VENV_DIR}"/bin/pip install -v "${IS_REQ_PREINSTALL_PIP}"
 else
     echo_red "Klipper Venv not found!"
     return 1
 fi
 
 ## Cleanup
-sudo -u ${BASE_USER} rm -rf /home/${BASE_USER}/.cache
-popd
+echo_green "Cleanup ..."
+sudo -u "${BASE_USER}" rm -rf "/home/${BASE_USER}/.cache"
+popd  &> /dev/null || exit 1
 
 ## Enable spi interface by default
 echo_green "Enabling SPI Interface..."
-sed -i 's/#dtparam=spi=on/dtparam=spi=on/' ${IS_REQ_PREINSTALL_CFG_FILE} 
+sed -i 's/#dtparam=spi=on/dtparam=spi=on/' "${IS_REQ_PREINSTALL_CFG_FILE}"
 
-### EOF
+echo_green "Install Input Shaper requirements ... done!"

--- a/src/modules/klipper/config
+++ b/src/modules/klipper/config
@@ -1,3 +1,5 @@
+#!/bin/bash
+# shellcheck disable=all
 [ -n "$KLIPPER_SRC_DIR" ] || KLIPPER_SRC_DIR=/home/${BASE_USER}/klipper
 [ -n "$KLIPPER_PYTHON_DIR" ] || KLIPPER_PYTHON_DIR=/home/${BASE_USER}/klippy-env
 

--- a/src/modules/klipper/filesystem/root/etc/systemd/system/klipper.service
+++ b/src/modules/klipper/filesystem/root/etc/systemd/system/klipper.service
@@ -3,7 +3,7 @@
 [Unit]
 Description=Starts Klipper and provides klippy Unix Domain Socket API
 Documentation=https://www.klipper3d.org/
-After=network.target
+After=network-online.target
 Before=moonraker.service
 Wants=udev.target
 

--- a/src/modules/klipper/start_chroot_script
+++ b/src/modules/klipper/start_chroot_script
@@ -1,60 +1,83 @@
 #!/usr/bin/env bash
-# Klipper install script
-# Script that installs Klipper
-# Written by Raymond Himle and Stefan Dej
-# Revamped by KwadFan
-# Thanks to KevinOConnor
-# GPL V3
-########
+#### MainsailOS Build Chain
+####
+#### Klipper Install Module
+####
+#### Based on work done by Raymond Himle and Stefan Dej
+####
+#### Written by Stephan Wendel aka KwadFan <me@stephanwe.de>
+#### Copyright 2022
+#### https://github.com/mainsail-crew/MainsailOS
+####
+#### This File is distributed under GPLv3
+####
+
+# shellcheck enable=require-variable-braces
 
 ### For easier maintainability look to klipper/config.
 
 ## Source error handling, leave this in place
-set -xe
+set -Eex
 
-# Source CustomPIOS common.sh
+## Set LC_ALL to prevent errors
+export LC_ALL=C
+
+# Set DEBIAN_FRONTEND to noninteractive
+if [ "${DEBIAN_FRONTEND}" != "noninteractive" ]; then
+    export DEBIAN_FRONTEND=noninteractive
+fi
+
+## Source CustomPIOS common.sh
+# shellcheck disable=SC1091
 source /common.sh
 install_cleanup_trap
 
 unpack /filesystem/root /
 
-echo_green "Installing Klipper and enable klippy Service"
+echo_green "Installing Klipper and enable klippy Service ..."
 
-### install all deps at once for time consumption reasons.
+## Install all deps at once for time consumption reasons.
 ## APT: Update Repo Database and install Dependencies
+# Force apt update
+apt update
+echo_green "Installing Klipper Dependencies ..."
+## Disabling shellcheck SC2086, because we want "wordsplitting"
+# shellcheck disable=SC2086
+check_install_pkgs ${KLIPPER_DEPS}
 
-apt update && apt install ${KLIPPER_DEPS} -y
-
-### Make sure user pi has access to serial ports
+## Make sure user pi has access to serial ports
 ## NOTE: BASE_USER is defined by CustomPIOS Variable
 ## there for if you plan to set something else than "pi"
 ## Currently CustomPIOS uses "pi"
 
-usermod -a -G ${KLIPPER_USER_GROUPS} ${BASE_USER}
+usermod -a -G "${KLIPPER_USER_GROUPS}" "${BASE_USER}"
 
-### clone klipper repo
-pushd /home/${BASE_USER}
+## Clone klipper repo
+pushd "/home/${BASE_USER}" &> /dev/null || exit 1
 gitclone KLIPPER_REPO klipper
 
-### Create needed dirs
-for dirs in ${KLIPPER_USER_DIRS}; do
-    if [ -d /home/$BASE_USER/$dirs ]; then
-        echo_green "$dirs already exists!"
+## Create needed dirs
+for dir in ${KLIPPER_USER_DIRS}; do
+    if [ -d "/home/${BASE_USER}/$dir" ]; then
+        echo_green "${dir} already exists!"
     else
-        echo_green "Creating $dirs"
-        sudo -u $BASE_USER mkdir -p $dirs
+        echo_green "Creating ${dir}"
+        sudo -u "${BASE_USER}" mkdir -p "${dir}"
     fi
 done
-popd
+popd &> /dev/null || exit 1
 
-# create python virtualenv and install klipper requirements
-pushd /home/${BASE_USER}
-echo_green "Creating Virtualenv for Klipper (klipper-env) ..."
-sudo -u ${BASE_USER} virtualenv -p python3 ${KLIPPER_PYTHON_DIR}
+## create python virtualenv and install klipper requirements
+pushd "/home/${BASE_USER}" &> /dev/null || exit 1
+echo_green "Creating Virtualenv for Klipper (klippy-env) ..."
+sudo -u "${BASE_USER}" virtualenv -p python3 "${KLIPPER_PYTHON_DIR}"
 echo_green "Installing klippy Python Dependencies ..."
-sudo -u ${BASE_USER} ${KLIPPER_PYTHON_DIR}/bin/pip install -r ${KLIPPER_SRC_DIR}/${KLIPPER_PYENV_REQ}
-popd
+sudo -u "${BASE_USER}" "${KLIPPER_PYTHON_DIR}"/bin/pip install -r "${KLIPPER_SRC_DIR}"/"${KLIPPER_PYENV_REQ}"
+popd &> /dev/null || exit 1
 
 
-# enable systemd service
+## Enable systemd service
 systemctl_if_exists enable klipper.service
+
+## Done message
+echo_green "Installing Klipper and enable klippy Service ... done!"


### PR DESCRIPTION
Style: add new header

Style: refactored to match shellcheck requirements.

Improved:
Inherited error trap.
Set fallback lang to C.
Set DEBIAN_FRONTEND to noninteractive if not noninteractive.

Replaced apt install with check_install_pkgs

Fix: Use correct network-online.target instead network.target

Signed-off-by: Stephan Wendel <me@stephanwe.de>