### PR TITLE
feat(moonraker.conf): add mainsail subscription to announcements

### DIFF
--- a/src/modules/moonraker/filesystem/home/pi/klipper_config/moonraker.conf
+++ b/src/modules/moonraker/filesystem/home/pi/klipper_config/moonraker.conf
@@ -33,6 +33,11 @@ trusted_clients:
 # enables moonraker to track and store print history.
 [history]
 
+# this enables moonraker announcements for mainsail
+[announcements]
+subscriptions:
+    mainsail
+
 # this enables moonraker's update manager
 [update_manager]
 refresh_interval: 168


### PR DESCRIPTION
With the upcoming v2.2.0 release of Mainsail, Mainsail will support Moonraker announcements. Therefore it makes sense to already add Mainsail to the list of subscriptions by default.

Signed-off-by: Dominik Willner th33xitus@gmail.com