### PR TITLE
fix: correct on_error_gcode in mainsail.cfg

### DIFF
--- a/src/modules/mainsail/filesystem/home/pi/klipper_config/mainsail.cfg
+++ b/src/modules/mainsail/filesystem/home/pi/klipper_config/mainsail.cfg
@@ -4,7 +4,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license
 #
-# Version 1.10
+# Version 1.11
 
 # add [include mainsail.cfg] to your printer.cfg to include it to your printer.cfg
 # modify x_park, y_park, z_park_delta and extrude value at the macro _TOOLHEAD_PARK_PAUSE_CANCEL if needed
@@ -14,9 +14,7 @@
 [virtual_sdcard]
 path: ~/gcode_files
 on_error_gcode:
-  {% if error_message.startswith("Move exceeds maximum extrusion") %}
-    CANCEL_PRINT
-  {% endif %}
+  CANCEL_PRINT
 
 [pause_resume]
 


### PR DESCRIPTION
Removes any reference to `error_message` variable in the `on_gcode_error` block as this Klipper variable was removed before merging into master.

When this block of code runs the print will already have been stopped, so I do believe it will be safe to just call `CANCEL_PRINT` whatever the error was.

Related Klipper docs: https://www.klipper3d.org/Config_Reference.html#virtual_sdcard

Related to #116

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>