### PR TITLE
fix(config.txt): fix configuration errors with attached screens

### DIFF
--- a/src/modules/piconfig/filesystem/root/boot/config.txt
+++ b/src/modules/piconfig/filesystem/root/boot/config.txt
@@ -103,8 +103,7 @@ gpu_mem=256
 enable_uart=1
 dtoverlay=disable-bt
 
-## Enable Raspicam devices at boot
-## This also enables the X Server for KlipperScreen
+## Enable VideoCore at boot, needed for Raspicams and DSI devices.
 start_x=1
 
 ### EXPERIMENTAL - Enable 64bit Kernel

--- a/src/modules/piconfig/filesystem/root/boot/config.txt
+++ b/src/modules/piconfig/filesystem/root/boot/config.txt
@@ -1,76 +1,3 @@
-# For more options and information see
-# http://rpf.io/configtxt
-# Some settings may impact device functionality. See link above for details
-
-# uncomment if you get no picture on HDMI for a default "safe" mode
-#hdmi_safe=1
-
-# uncomment this if your display has a black border of unused pixels visible
-# and your display can output without overscan
-#disable_overscan=1
-
-# uncomment the following to adjust overscan. Use positive numbers if console
-# goes off screen, and negative if there is too much border
-#overscan_left=16
-#overscan_right=16
-#overscan_top=16
-#overscan_bottom=16
-
-# uncomment to force a console size. By default it will be display's size minus
-# overscan.
-#framebuffer_width=1280
-#framebuffer_height=720
-
-# uncomment if hdmi display is not detected and composite is being output
-#hdmi_force_hotplug=1
-
-# uncomment to force a specific HDMI mode (this will force VGA)
-#hdmi_group=1
-#hdmi_mode=1
-
-# uncomment to force a HDMI mode rather than DVI. This can make audio work in
-# DMT (computer monitor) modes
-#hdmi_drive=2
-
-# uncomment to increase signal to HDMI, if you have interference, blanking, or
-# no display
-#config_hdmi_boost=4
-
-# uncomment for composite PAL
-#sdtv_mode=2
-
-#uncomment to overclock the arm. 700 MHz is the default.
-#arm_freq=800
-
-# Uncomment some or all of these to enable the optional hardware interfaces
-#dtparam=i2c_arm=on
-#dtparam=i2s=on
-dtparam=spi=on
-
-# Uncomment this to enable infrared communication.
-#dtoverlay=gpio-ir,gpio_pin=17
-#dtoverlay=gpio-ir-tx,gpio_pin=18
-
-# Additional overlays and parameters are documented /boot/overlays/README
-
-# Enable audio (loads snd_bcm2835)
-dtparam=audio=on
-
-
-
-[pi0]
-## This affects Pi Zero(W) and Pi Zero2
-## Due lag of RAM, limit GPU RAM
-gpu_mem=128
-
-[pi4]
-## Enable DRM VC4 V3D driver on top of the dispmanx display stack
-dtoverlay=vc4-fkms-v3d
-max_framebuffers=2
-# Do not use more than 256Mb on Pi Model 4, it uses its own Management.
-gpu_mem=256
-
-[all]
 ####################################################
 ####     MainsailOS specific configurations     ####
 ####################################################
@@ -78,10 +5,43 @@ gpu_mem=256
 ####   UNLESS YOU KNOW WHAT YOU ARE DOING !!!   ####
 ####################################################
 
+## For more options and information see
+## https://www.raspberrypi.com/documentation/computers/config_txt.html
+## Some settings may impact device functionality. See link above for details
+
+## For additional information about device filters see
+## https://www.raspberrypi.com/documentation/computers/config_txt.html#model-filters
+
+
+[pi0]
+## This affects Pi Zero(W) and Pi Zero2
+## Due lag of RAM, limit GPU RAM
+gpu_mem=128
+
+[pi2]
+gpu_mem=256
+
+[pi3]
+## Use 256 if 1Gb Ram Model!
+gpu_mem=128
+# gpu_mem=256
+
+[pi4]
+## Enable DRM VC4 V3D driver on top of the dispmanx display stack
+dtoverlay=vc4-fkms-v3d
+max_framebuffers=2
+## Do not use more than 256Mb on Pi Model 4, it uses its own Management.
+gpu_mem=256
+
+[all]
+
+# Enable audio (loads snd_bcm2835)
+dtparam=audio=on
+
 ## SPI Interface is enabled by default for Input Shaper
 ## To revert that comment out line #48
 ## This colides with Hyperpixel Display!
-## Hyperpixel Scrren uses the same Pin for Backlight.
+## Hyperpixel Screen uses the same Pin for Backlight.
 
 ## Enable Hardware UART for Serial Communication
 enable_uart=1
@@ -90,6 +50,11 @@ dtoverlay=disable-bt
 ## Enable Raspicam devices at boot
 ## This also enables the X Server for KlipperScreen
 start_x=1
-gpu_mem=256
+
+### EXPERIMENTAL - Enable 64bit Kernel
+### The 64-bit kernel will only work on:
+### Raspberry Pi 3, 3+, 4, 400, Zero 2 W and 2B rev 1.2
+### and Raspberry Pi Compute Modules 3, 3+ and 4.
+# arm_64bit=1
 
 ####################################################

--- a/src/modules/piconfig/filesystem/root/boot/config.txt
+++ b/src/modules/piconfig/filesystem/root/boot/config.txt
@@ -53,6 +53,9 @@ dtparam=spi=on
 
 # Additional overlays and parameters are documented /boot/overlays/README
 
+# Enable audio (loads snd_bcm2835)
+dtparam=audio=on
+
 
 ####################################################
 ####     MainsailOS specific configurations     ####
@@ -90,9 +93,6 @@ max_framebuffers=2
 gpu_mem=256
 
 [all]
-
-# Enable audio (loads snd_bcm2835)
-dtparam=audio=on
 
 ## SPI Interface is enabled by default for Input Shaper
 ## To revert that comment out line #48

--- a/src/modules/piconfig/filesystem/root/boot/config.txt
+++ b/src/modules/piconfig/filesystem/root/boot/config.txt
@@ -1,3 +1,59 @@
+# For more options and information see
+# http://rpf.io/configtxt
+# Some settings may impact device functionality. See link above for details
+
+# uncomment if you get no picture on HDMI for a default "safe" mode
+#hdmi_safe=1
+
+# uncomment this if your display has a black border of unused pixels visible
+# and your display can output without overscan
+#disable_overscan=1
+
+# uncomment the following to adjust overscan. Use positive numbers if console
+# goes off screen, and negative if there is too much border
+#overscan_left=16
+#overscan_right=16
+#overscan_top=16
+#overscan_bottom=16
+
+# uncomment to force a console size. By default it will be display's size minus
+# overscan.
+#framebuffer_width=1280
+#framebuffer_height=720
+
+# uncomment if hdmi display is not detected and composite is being output
+#hdmi_force_hotplug=1
+
+# uncomment to force a specific HDMI mode (this will force VGA)
+#hdmi_group=1
+#hdmi_mode=1
+
+# uncomment to force a HDMI mode rather than DVI. This can make audio work in
+# DMT (computer monitor) modes
+#hdmi_drive=2
+
+# uncomment to increase signal to HDMI, if you have interference, blanking, or
+# no display
+#config_hdmi_boost=4
+
+# uncomment for composite PAL
+#sdtv_mode=2
+
+#uncomment to overclock the arm. 700 MHz is the default.
+#arm_freq=800
+
+# Uncomment some or all of these to enable the optional hardware interfaces
+#dtparam=i2c_arm=on
+#dtparam=i2s=on
+dtparam=spi=on
+
+# Uncomment this to enable infrared communication.
+#dtoverlay=gpio-ir,gpio_pin=17
+#dtoverlay=gpio-ir-tx,gpio_pin=18
+
+# Additional overlays and parameters are documented /boot/overlays/README
+
+
 ####################################################
 ####     MainsailOS specific configurations     ####
 ####################################################

--- a/src/modules/piconfig/filesystem/root/boot/config.txt
+++ b/src/modules/piconfig/filesystem/root/boot/config.txt
@@ -56,29 +56,40 @@ dtparam=spi=on
 # Enable audio (loads snd_bcm2835)
 dtparam=audio=on
 
+
+
+[pi0]
+## This affects Pi Zero(W) and Pi Zero2
+## Due lag of RAM, limit GPU RAM
+gpu_mem=128
+
 [pi4]
-# Enable DRM VC4 V3D driver on top of the dispmanx display stack
+## Enable DRM VC4 V3D driver on top of the dispmanx display stack
 dtoverlay=vc4-fkms-v3d
 max_framebuffers=2
 # Do not use more than 256Mb on Pi Model 4, it uses its own Management.
 gpu_mem=256
 
 [all]
-#dtoverlay=vc4-fkms-v3d
+####################################################
+####     MainsailOS specific configurations     ####
+####################################################
+####      DO NOT CHANGE SECTION BELOW !!!       ####
+####   UNLESS YOU KNOW WHAT YOU ARE DOING !!!   ####
+####################################################
 
-# Enable Hardware UART for Serial Communication
+## SPI Interface is enabled by default for Input Shaper
+## To revert that comment out line #48
+## This colides with Hyperpixel Display!
+## Hyperpixel Scrren uses the same Pin for Backlight.
+
+## Enable Hardware UART for Serial Communication
 enable_uart=1
 dtoverlay=disable-bt
 
-# Enable Raspicam devices at boot
+## Enable Raspicam devices at boot
+## This also enables the X Server for KlipperScreen
 start_x=1
 gpu_mem=256
 
-## Zero Models need special handling
-[pi0w]
-dtoverlay=pi3-disable-bt
-gpu_mem=128
-
-[pi02]
-gpu_mem=128
-
+####################################################


### PR DESCRIPTION
This should fix errors with installers of Raspi Screens,
they expect [all] section at last for appending special
configurations.

Signed-off-by: Stephan Wendel <me@stephanwe.de>