### PR TITLE
chore: add wireless-tools as moonraker dependency

### DIFF
--- a/src/modules/moonraker/start_chroot_script
+++ b/src/modules/moonraker/start_chroot_script
@@ -16,7 +16,7 @@ install_cleanup_trap
 
 # make sure that this module can be used standalone
 apt_update_skip
-check_install_pkgs "git virtualenv"
+check_install_pkgs "git virtualenv wireless-tools"
 
 echo_green "Installing Moonraker and enable Moonraker Service"
 # install MainsailOS premade moonraker.conf


### PR DESCRIPTION
Dependency 'wireless-tools' needed by moonraker for 'iwgetid'

Signed-off-by: Stephan Wendel <me@stephanwe.de>