### PR TITLE
fix: fix errors in moved venvs

### DIFF
--- a/src/modules/postrename/config
+++ b/src/modules/postrename/config
@@ -9,4 +9,4 @@
 ####
 # shellcheck disable=all
 
-[ -n "$POSTRENAME_DEPS" ] || POSTRENAME_DEPS="python3-pip"
+# Intentionally left blank

--- a/src/modules/postrename/config
+++ b/src/modules/postrename/config
@@ -9,4 +9,4 @@
 ####
 # shellcheck disable=all
 
-# Intentionaly left blank
+[ -n "$POSTRENAME_DEPS" ] || POSTRENAME_DEPS="python3-pip"

--- a/src/modules/postrename/filesystem/root/postrename
+++ b/src/modules/postrename/filesystem/root/postrename
@@ -75,8 +75,20 @@ function relocate_venv {
     venvs=(klippy-env moonraker-env)
 
     for venv in "${venvs[@]}"; do
+        # Move venv
         sudo -u "${DEFAULT_USER}" \
         virtualenv --relocatable -p /usr/bin/python3 "/home/${DEFAULT_USER}/${venv}"
+
+        # delete pycache (*.pyc files)
+        find "/home/${DEFAULT_USER}/${venv}" -name "__pycache__" -type d -exec rm -rf {} +
+
+        # repair shebangs
+        while IFS= read -r file ; do
+
+            sed -i 's|pi/'"${venv}"'|'"${DEFAULT_USER}"'/'"${venv}"'|g' "${file}"
+
+        done < <(grep -iR "pi/${venv}" "/home/${DEFAULT_USER}/${venv}"/* | cut -d":" -f1)
+
     done
 }
 

--- a/src/modules/postrename/start_chroot_script
+++ b/src/modules/postrename/start_chroot_script
@@ -17,13 +17,6 @@ set -xe
 source /common.sh
 install_cleanup_trap
 
-# Install pip3 systemwide
-# shellcheck disable=SC2086
-check_install_pkgs ${POSTRENAME_DEPS}
-
-# Install virtualenv-tools3
-sudo -u "${BASE_USER}" pip3 install --user virtualenv-tools3
-
 ## unpack postrename
 unpack filesystem/root / root
 ## set executable

--- a/src/modules/postrename/start_chroot_script
+++ b/src/modules/postrename/start_chroot_script
@@ -17,6 +17,13 @@ set -xe
 source /common.sh
 install_cleanup_trap
 
+# Install pip3 systemwide
+# shellcheck disable=SC2086
+check_install_pkgs ${POSTRENAME_DEPS}
+
+# Install virtualenv-tools3
+sudo -u "${BASE_USER}" pip3 install --user virtualenv-tools3
+
 ## unpack postrename
 unpack filesystem/root / root
 ## set executable


### PR DESCRIPTION
This should fix #136

Due moving venv's with virtualenv,
some path aren't get changed.

Now pycache will be deleted and
shebang lines manipulated to match paths

Signed-off-by: Stephan Wendel <me@stephanwe.de>