### PR TITLE
chore: add additional Input shaper dependencies

### DIFF
--- a/src/modules/is_req_preinstall/config
+++ b/src/modules/is_req_preinstall/config
@@ -1,6 +1,7 @@
 #!/bin/bash
 # shellcheck disable=all
 [ -n "$IS_REQ_PREINSTALL_VENV_DIR" ] || IS_REQ_PREINSTALL_VENV_DIR=/home/${BASE_USER}/klippy-env
-[ -n "$IS_REQ_PREINSTALL_DEPS" ] || IS_REQ_PREINSTALL_DEPS="python3-numpy python3-matplotlib"
+[ -n "$IS_REQ_PREINSTALL_DEPS" ] || IS_REQ_PREINSTALL_DEPS="python3-numpy python3-matplotlib \
+libatlas3-base libatlas-base-dev"
 [ -n "$IS_REQ_PREINSTALL_PIP" ] || IS_REQ_PREINSTALL_PIP="numpy<=1.21.4"
 [ -n "$IS_REQ_PREINSTALL_CFG_FILE" ] || IS_REQ_PREINSTALL_CFG_FILE="/boot/config.txt"


### PR DESCRIPTION
Input Shaper now needs libatlas3-base and libatlas-base-dev
as additional dependencies

Signed-off-by: Stephan Wendel <me@stephanwe.de>