### PR TITLE
fix: fixes error unusable wpa_supplicant.txt

### DIFF
--- a/src/config
+++ b/src/config
@@ -4,6 +4,6 @@
 export DIST_NAME=MainsailOS
 export DIST_VERSION=0.7.0
 export BASE_IMAGE_ENLARGEROOT=2500
-export MODULES="base,pkgupgrade,mainsailos(network,piconfig,klipper,is_req_preinstall,moonraker,timelapse,mainsail,crowsnest,sonar,password-for-sudo),postrename"
+export MODULES="base,pkgupgrade,mainsailos(net,piconfig,klipper,is_req_preinstall,moonraker,timelapse,mainsail,crowsnest,sonar,password-for-sudo),postrename"
 export BASE_RELEASE_COMPRESS=yes
 export BASE_IMAGE_RESIZEROOT=600

--- a/src/modules/net/config
+++ b/src/modules/net/config
@@ -1,0 +1,13 @@
+# Network module setup
+# shellcheck disable=all
+
+# Use disable power save for wifi module
+[ -n "$NETWORK_DISABLE_PWRSAVE" ] || NETWORK_DISABLE_PWRSAVE=yes
+
+# Type of power save rclocal/service/udev
+# rclocal - backwards compatibility, runs via rc.local
+# service - will add an systemd.service to enable or disable behavior
+# on reboots
+# udev - creates a udev rules that should affect all wifi devices.
+
+[ -n "$NETWORK_PWRSAVE_TYPE" ] || NETWORK_PWRSAVE_TYPE=udev

--- a/src/modules/net/filesystem/boot/WiFi-README.txt
+++ b/src/modules/net/filesystem/boot/WiFi-README.txt
@@ -1,0 +1,163 @@
+Wifi-README.txt
+###############
+
+
+Due to changes in Raspberry Pi OS, which is OS_NAME is based on,
+there is no longer a OS_NAME-wpa-supplicant.txt available.
+
+How do I setup a (new) network on my Pi ?
+-----------------------------------------
+
+As described in the original Raspberry Pi OS documentation.
+See https://www.raspberrypi.com/documentation/computers/configuration.html#setting-up-a-headless-raspberry-pi.
+
+
+Quote:
+    You will need to define a wpa_supplicant.conf file for your particular wireless network.
+    Put this file onto the boot folder of the SD card.
+    When the Raspberry Pi boots for the first time,
+    it will copy that file into the correct location in the Linux root file system
+    and use those settings to start up wireless networking.
+
+    The Raspberry Pi’s IP address will not be visible immediately after power on,
+    so this step is crucial to connect to it headlessly.
+    Depending on the OS and editor you are creating this on,
+    the file could have incorrect newlines or the wrong file extension,
+    so make sure you use an editor that accounts for this.
+    Linux expects the line feed (LF) newline character.
+
+What does that all mean? What have I todo now?
+----------------------------------------------
+
+For short, get a proper text editor of your choice.
+Recommendations are Notepad++, VSCode, Atom or SublimeText.
+
+################################################################################
+####                       IMPORTANT! ATTENTION!                            ####
+################################################################################
+
+!!!!! HEADS-UP WINDOWS USERS !!!!!
+----------------------------------
+
+Do not use Wordpad for editing this file, it will mangle it and your
+configuration won't work. Use a proper text editor instead.
+
+!!!!! HEADS-UP MACOSX USERS !!!!!
+---------------------------------
+
+If you use Textedit to edit this file make sure to use "plain text format"
+and "disable smart quotes" in "Textedit > Preferences", otherwise Textedit
+will use none-compatible characters and your network configuration won't work!
+
+
+1.) Open your choosen Texteditor and create a new file called
+
+    wpa_supplicant.conf
+
+2.) Create a some basic configuration. This has to be in place!
+
+    ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+    country=<Insert 2 letter ISO 3166-1 country code here>
+    update_config=1
+
+Valid Country Codes are:
+
+    GB (United Kingdom)
+    FR (France)
+    DE (Germany)
+    US (United States)
+    SE (Sweden)
+
+For a full list, please visit https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+
+2.1) If you plan to use multiple WiFi networks, also add
+
+    ap_scan=1
+
+to the mentioned basic configuration.
+
+
+3.) Setup your "network" block.
+
+For detailed information, please consult:
+https://linux.die.net/man/5/wpa_supplicant.conf
+or
+https://wiki.debian.org/WiFi/HowToUse#wpa_supplicant
+or
+https://man.archlinux.org/man/wpa_supplicant.conf.5
+
+Examples:
+
+Open or unsecured WiFi network:
+-------------------------------
+
+# Open/unsecured
+network={
+  scan_ssid=1 # Used to find hidden SSID's
+  ssid="put SSID here"
+  key_mgmt=NONE
+}
+
+-------------------------------
+
+
+WEP "secured" network:
+-------------------------------
+
+NOTE:
+
+    WEP can be cracked within minutes. If your network is still relying on this
+    encryption scheme you should seriously consider to update your network ASAP.
+
+network={
+  ssid="put SSID here"
+  key_mgmt=NONE
+  wep_key0="put password here"
+  wep_tx_keyidx=0
+}
+--------------------------------
+
+
+WPA2 Personal secured network:
+(Please don't use WPA secured networks, WPA isn't secure anymore)
+--------------------------------
+
+# WPA/WPA2 secured
+network={
+        scan_ssid=1 # Used to find hidden SSID's
+        ssid="<Name of your wireless LAN>"
+        psk="<Password for your wireless LAN>"
+        proto=RSN
+        key_mgmt=WPA-PSK
+        pairwise=CCMP
+        auth_alg=OPEN
+}
+--------------------------------
+
+For the WPA2 Enterprise setup, please use your google-foo.
+This is an advanced topic!
+
+4.) Put that file on to the "/boot" partition,
+this partition is FAT32 formatted and should be visible if you plug the SD Card into your computer.
+
+If you created a file while the Pi was running, copy that file to boot.
+Assuming you created the file in your users "home" directory use
+
+    sudo cp -v wpa_supplicant.conf /boot/
+
+5.) Almost done... Please reboot the pi and wait for it to connect.
+
+NOTE:
+
+Attach a screen and watch the console output to get its IP or
+consult your Router setup page to grab that information.
+
+You could also try to reach it by its hostname.
+
+    http://<yourpisname>.local
+
+If you didnt change the hostname during initial flash, you could use
+
+    http://OS_NAME.local
+
+6.) Enjoy OS_NAME :)

--- a/src/modules/net/filesystem/boot/wpa_supplicant.conf.example
+++ b/src/modules/net/filesystem/boot/wpa_supplicant.conf.example
@@ -1,0 +1,15 @@
+# Simple configuration for a typical WPA2 network
+
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+update_config=1
+country=US # US Country code
+
+network={
+        scan_ssid=1
+        ssid="<Name of your wireless LAN>"
+        psk="<Password for your wireless LAN>"
+        proto=RSN
+        key_mgmt=WPA-PSK
+        pairwise=CCMP
+        auth_alg=OPEN
+}

--- a/src/modules/net/filesystem/etc/systemd/system/disable-wifi-pwr-mgmt.service
+++ b/src/modules/net/filesystem/etc/systemd/system/disable-wifi-pwr-mgmt.service
@@ -1,0 +1,22 @@
+#### Disable wifi power_save
+####
+#### Written by Stephan Wendel aka KwadFan <me@stephanwe.de>
+#### Copyright 2022
+#### https://github.com/mainsail-crew/MainsailOS
+####
+#### This File is distributed under GPLv3
+####
+#### Note: This is based on:
+#### https://www.intel.com/content/www/us/en/support/articles/000006168/boards-and-kits.html
+
+[Unit]
+Description=Disable power management for wlan0
+After=network.target
+
+[Service]
+Type=oneshot
+StandardOutput=tty
+ExecStart=/usr/local/bin/pwrsave off
+
+[Install]
+WantedBy=multi-user.target

--- a/src/modules/net/filesystem/etc/udev/rules.d/070-wifi-powersave.rules
+++ b/src/modules/net/filesystem/etc/udev/rules.d/070-wifi-powersave.rules
@@ -1,0 +1,4 @@
+ACTION=="add", \
+SUBSYSTEM=="net", \
+KERNEL=="wlan*" \
+RUN+="/usr/sbin/iw %k set power_save off"

--- a/src/modules/net/filesystem/usr/local/bin/pwrsave
+++ b/src/modules/net/filesystem/usr/local/bin/pwrsave
@@ -1,0 +1,90 @@
+#!/bin/bash
+#### Disable wifi power_save
+####
+#### Written by Stephan Wendel aka KwadFan <me@stephanwe.de>
+#### Copyright 2022
+#### https://github.com/mainsail-crew/MainsailOS
+####
+#### This File is distributed under GPLv3
+####
+#### Note: This is based on:
+#### https://www.intel.com/content/www/us/en/support/articles/000006168/boards-and-kits.html
+
+
+## Error handling
+set -eou pipefail
+
+## Debug Mode
+#set -x
+
+### Message func
+function help_msg {
+    echo -e "Usage:\n"
+    echo -e "\tpwrsave [ on | off ]"
+    echo -e "\t\ton\tEnables Power Management of 'wlan0'"
+    echo -e "\t\toff\tDisables Power Management of 'wlan0'\n"
+    exit 1
+}
+
+function has_wifi {
+    LC_ALL=C iwconfig wlan0 &> /dev/null && echo "0" || echo "1"
+}
+
+function check_wifi_present {
+    # make sure to exit if command missing
+    if [ -z "$(command -v iwconfig)" ]; then
+        echo -e "Command 'iwconfig' not found ... [EXITING]"
+        exit 1
+    fi
+    if [ "$(has_wifi)" != "0" ]; then
+        echo -e "[ \e[33mWARN\e[0m ] No WiFi hardware present ... [SKIPPED]"
+        exit 0
+    fi
+}
+
+function disable_pwr_save {
+    iwconfig wlan0 power off
+    echo -e "[  \e[32mOK\e[0m  ] Disabled Power Management for wlan0"
+}
+
+
+function enable_pwr_save {
+    iwconfig wlan0 power on
+    echo -e "[  \e[32mOK\e[0m  ] Enabled Power Management for wlan0"
+}
+
+
+### MAIN
+function main {
+    local arg
+    if [ "$(id -u)" != "0" ]; then
+        echo -e "\n$(basename "${0}"): This script needs root priviledges!\n"
+        exit 1
+    fi
+    if [ "${#}" == "0" ]; then
+        echo -e "$(basename "${0}"): No argument set!"
+        help_msg
+    fi
+    if [ "${#}" -gt 1 ]; then
+        echo -e "$(basename "${0}"): Too many arguments set!"
+        help_msg
+    fi
+    arg="${1}"
+    case "${arg}" in
+        "on")
+            check_wifi_present
+            enable_pwr_save
+        ;;
+        "off")
+            check_wifi_present
+            disable_pwr_save
+        ;;
+        ?|*)
+            echo -e "$(basename "${0}"): Unknown argument '${arg}' !"
+            help_msg
+        ;;
+    esac
+}
+
+main "${@}"
+exit 0

--- a/src/modules/net/filesystem/usr/local/bin/pwrsave-udev
+++ b/src/modules/net/filesystem/usr/local/bin/pwrsave-udev
@@ -1,0 +1,105 @@
+#!/bin/bash
+#### Disable wifi power_save
+####
+#### Written by Stephan Wendel aka KwadFan <me@stephanwe.de>
+#### Copyright 2022
+#### https://github.com/mainsail-crew/MainsailOS
+####
+#### This File is distributed under GPLv3
+####
+#### Note: This is based on:
+#### https://www.intel.com/content/www/us/en/support/articles/000006168/boards-and-kits.html
+
+
+## Error handling
+set -eou pipefail
+
+## Debug Mode
+#set -x
+
+### Message func
+function help_msg {
+    echo -e "Usage:\n"
+    echo -e "\tpwrsave-udev [ on | off | create ]"
+    echo -e "\t\ton\tEnables Power Management via udev rule"
+    echo -e "\t\toff\tDisables Power Management via udev rule"
+    echo -e "\t\tcreate\tCreate Power Management udev rule\n"
+    exit 1
+}
+
+
+### Check rule exist
+function check_rule {
+    if [ ! -f /etc/udev/rules.d/070-wifi-powersave.rules ]; then
+        echo -e "[  \e[31mERROR\e[0m  ] Udev Rule for WiFi Powermanagement not found!"
+        help_msg
+        exit 1
+    fi
+}
+
+function disable_pwr_save {
+    sed -i 's/on/off/' /etc/udev/rules.d/070-wifi-powersave.rules
+    echo -e "[  \e[32mOK\e[0m  ] Disabled Power Management"
+}
+
+
+function enable_pwr_save {
+    sed -i 's/off/on/' /etc/udev/rules.d/070-wifi-powersave.rules
+    echo -e "[  \e[32mOK\e[0m  ] Enabled Power Management"
+}
+
+function create_rule {
+if [ -f /etc/udev/rules.d/070-wifi-powersave.rules ]; then
+    echo -e "[  \e[33mSKIPPED\e[0m  ] Udev rule already exists!"
+    exit 0
+fi
+
+cat << EOF > /etc/udev/rules.d/070-wifi-powersave.rules
+ACTION=="add", \
+SUBSYSTEM=="net", \
+KERNEL=="wlan*" \
+RUN+="/usr/sbin/iw %k set power_save off"
+EOF
+echo -e "[  \e[32mOK\e[0m  ] Created Udev rule ... \n"
+echo -e "Please 'reboot' to take changes effect.\n"
+}
+
+
+
+### MAIN
+function main {
+    local arg
+    if [ "$(id -u)" != "0" ]; then
+        echo -e "\n$(basename "${0}"): This script needs root priviledges!\n"
+        exit 1
+    fi
+    if [ "${#}" == "0" ]; then
+        echo -e "$(basename "${0}"): No argument set!"
+        help_msg
+    fi
+    if [ "${#}" -gt 1 ]; then
+        echo -e "$(basename "${0}"): Too many arguments set!"
+        help_msg
+    fi
+    arg="${1}"
+    if [ "${arg}" == "create" ]; then
+        create_rule
+        exit 0
+    fi
+    check_rule
+    case "${arg}" in
+        "on")
+            enable_pwr_save
+        ;;
+        "off")
+            disable_pwr_save
+        ;;
+        ?|*)
+            echo -e "$(basename "${0}"): Unknown argument '${arg}' !"
+            help_msg
+        ;;
+    esac
+}
+
+main "${@}"
+exit 0

--- a/src/modules/net/start_chroot_script
+++ b/src/modules/net/start_chroot_script
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Network
+# Adds to /boot configuration files that let you set up wifi network before booting
+# Written by Guy Sheffer <guysoft at gmail dot com> and Gina Häußge <gina@octoprint.org>
+# GPL V3
+#
+# Modified by Stephan Wendel aka KwadFan <me@stephanwe.de>
+# https://github.com/mainsail-crew/MainsailOS
+# Last modification: August/2022
+#
+########
+set -x
+set -e
+
+export LC_ALL=C
+
+source /common.sh
+install_cleanup_trap
+
+unpack /filesystem/boot /"${BASE_BOOT_MOUNT_PATH}"
+
+if [ "${BASE_DISTRO}" == "ubuntu" ] || [ "${BASE_DISTRO}" == "armbian" ]; then
+    echo "ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev" > /etc/wpa_supplicant/wpa_supplicant.conf
+    echo "update_config=1" >> /etc/wpa_supplicant/wpa_supplicant.conf
+    echo "ap_scan=1" >> /etc/wpa_supplicant/wpa_supplicant.conf
+    echo "country=US" >> /etc/wpa_supplicant/wpa_supplicant.conf
+fi
+
+if [ "${BASE_DISTRO}" == "raspbian" ]; then
+    # Workaround rfkill not unblocking on boot
+    rm /var/lib/systemd/rfkill/*
+fi
+
+# set OS_NAME in Wifi-README.txt according to DIST_NAME
+if [ -f "/boot/WiFi-README.txt" ]; then
+    sed -i 's|OS_NAME|'"${DIST_NAME}"'|g' /boot/WiFi-README.txt
+fi
+
+
+# copy /etc/wpa_supplicant/ifupdown.sh to /etc/ifplugd/action.d/ifupdown - for wlan auto reconnect
+[ -f /etc/ifplugd/action.d/ifupdown ] && mv /etc/ifplugd/action.d/ifupdown /etc/ifplugd/action.d/ifupdown.original
+[ -f /etc/wpa_supplicant/ifupdown.sh ] && ln -s /etc/wpa_supplicant/ifupdown.sh /etc/ifplugd/action.d/ifupdown
+
+if [ ! -f "/etc/rc.local" ];then
+    echo 'exit 0' >> /etc/rc.local
+fi
+
+# prevent ntp updates from failing due to some Rpi3 weirdness, see also "Fix SSH" further below
+apt-get update --allow-releaseinfo-change
+apt-get install -y iptables
+sed -i 's@exit 0@@' /etc/rc.local
+echo '/sbin/iptables -t mangle -I POSTROUTING 1 -o wlan0 -p udp --dport 123 -j TOS --set-tos 0x00' >> /etc/rc.local
+echo 'exit 0' >> /etc/rc.local
+
+# Install powersave option
+if [ "$NETWORK_DISABLE_PWRSAVE" == "yes" ]; then
+
+  # Copy pwrsave script
+  unpack filesystem/usr/local/bin /usr/local/bin root
+
+  # Use rc.local
+  if [ "$NETWORK_PWRSAVE_TYPE" == "rclocal" ]; then
+    echo_green "Modifying /etc/rc.local ..."
+    sed -i 's@exit 0@@' /etc/rc.local
+    (echo "# Disable WiFi Power Management"; \
+    echo 'echo "Disabling power management for wlan0 ..."' ; \
+    echo "/usr/local/bin/pwrsave off"; echo "exit 0") >> /etc/rc.local
+  fi
+  # Use service
+  if [ "$NETWORK_PWRSAVE_TYPE" == "service" ]; then
+    echo_green "Installing disable-wifi-pwr-mgmt service ..."
+    unpack filesystem/etc/systemd/system /etc/systemd/system root
+    systemctl_if_exists enable disable-wifi-pwr-mgmt.service
+  fi
+  # Use udev rule
+  if [ "$NETWORK_PWRSAVE_TYPE" == "udev" ]; then
+    echo_green "Installing WiFi Power Management udev rule ..."
+    unpack filesystem/etc/udev/rules.d /etc/udev/rules.d root
+  fi
+  # strip out unneeded script, depending on choose
+  if [ "$NETWORK_PWRSAVE_TYPE" != "udev" ]; then
+    rm -f /usr/local/bin/pwrsave-udev
+  else
+    rm -f /usr/local/bin/pwrsave
+  fi
+fi


### PR DESCRIPTION
This is more a workaround as a fix.
Raspberry Foundation changed handling of wpa_supplicant.conf.

Also KlipperScreen uses wpa_cli which overrides softlink to txt.

fixes #134

Signed-off-by: Stephan Wendel <me@stephanwe.de>