### PR TITLE
chore: update versions according to bullseye

### DIFF
--- a/src/modules/is_req_preinstall/config
+++ b/src/modules/is_req_preinstall/config
@@ -3,5 +3,5 @@
 [ -n "$IS_REQ_PREINSTALL_VENV_DIR" ] || IS_REQ_PREINSTALL_VENV_DIR=/home/${BASE_USER}/klippy-env
 [ -n "$IS_REQ_PREINSTALL_DEPS" ] || IS_REQ_PREINSTALL_DEPS="python3-numpy python3-matplotlib \
 libatlas3-base libatlas-base-dev"
-[ -n "$IS_REQ_PREINSTALL_PIP" ] || IS_REQ_PREINSTALL_PIP="numpy<=1.21.4"
+[ -n "$IS_REQ_PREINSTALL_PIP" ] || IS_REQ_PREINSTALL_PIP="numpy<=1.23.2"
 [ -n "$IS_REQ_PREINSTALL_CFG_FILE" ] || IS_REQ_PREINSTALL_CFG_FILE="/boot/config.txt"

--- a/src/modules/is_req_preinstall/config
+++ b/src/modules/is_req_preinstall/config
@@ -3,5 +3,5 @@
 [ -n "$IS_REQ_PREINSTALL_VENV_DIR" ] || IS_REQ_PREINSTALL_VENV_DIR=/home/${BASE_USER}/klippy-env
 [ -n "$IS_REQ_PREINSTALL_DEPS" ] || IS_REQ_PREINSTALL_DEPS="python3-numpy python3-matplotlib \
 libatlas3-base libatlas-base-dev"
-[ -n "$IS_REQ_PREINSTALL_PIP" ] || IS_REQ_PREINSTALL_PIP="numpy<=1.23.2"
+[ -n "$IS_REQ_PREINSTALL_PIP" ] || IS_REQ_PREINSTALL_PIP="numpy<=1.21.4"
 [ -n "$IS_REQ_PREINSTALL_CFG_FILE" ] || IS_REQ_PREINSTALL_CFG_FILE="/boot/config.txt"

--- a/src/modules/klipper/config
+++ b/src/modules/klipper/config
@@ -11,7 +11,7 @@ libffi-dev build-essential \
 libncurses-dev libusb-dev \
 avrdude gcc-avr binutils-avr avr-libc \
 stm32flash dfu-util libnewlib-arm-none-eabi \
-gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0"
+gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0-0"
 [ -n "$KLIPPER_USER_GROUPS" ] || KLIPPER_USER_GROUPS=tty,dialout
 [ -n "$KLIPPER_USER_DIRS" ] || KLIPPER_USER_DIRS="klipper_config klipper_logs gcode_files"
 [ -n "$KLIPPER_PYENV_REQ" ] || KLIPPER_PYENV_REQ=scripts/klippy-requirements.txt


### PR DESCRIPTION
libusb-1.0 has been renamed to libusb-1.0-0

numpy is available as piwheels package with version 1.23.2
(released 2022-08-14)

Signed-off-by: Stephan Wendel <me@stephanwe.de>