### PR TITLE
fix: fix postrename script

### DIFF
--- a/src/modules/postrename/filesystem/root/postrename
+++ b/src/modules/postrename/filesystem/root/postrename
@@ -76,9 +76,6 @@ function relocate_venv {
 
     for venv in "${venvs[@]}"; do
         # Move venv
-        sudo -u "${DEFAULT_USER}" \
-        virtualenv --relocatable -p /usr/bin/python3 "/home/${DEFAULT_USER}/${venv}"
-
         # delete pycache (*.pyc files)
         find "/home/${DEFAULT_USER}/${venv}" -name "__pycache__" -type d -exec rm -rf {} +
 


### PR DESCRIPTION
Obsolete option '--relocateable' introduces error. Removed virtualenv relocate,
only remove pycache and fix hardcoded paths

Signed-off-by: Stephan Wendel <me@stephanwe.de>