### PR TITLE
chore: add commit linter

### DIFF
--- a/.github/workflows/CommitLint.yml
+++ b/.github/workflows/CommitLint.yml
@@ -1,0 +1,18 @@
+name: "Linter: Commit Lint"
+on:
+  push:
+    branches:
+      - "**"
+    tags-ignore:
+      - "**"
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  commitlinter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v4


### PR DESCRIPTION
Adds action wagoid/commitlint-github-action as Commit Linter (Conventional Commits)

Signed-off-by: Stephan Wendel <me@stephanwe.de>