### PR TITLE
chore: removes fkms overlays

### DIFF
--- a/src/modules/piconfig/filesystem/tmp/msos_config.txt
+++ b/src/modules/piconfig/filesystem/tmp/msos_config.txt
@@ -28,9 +28,6 @@ gpu_mem=128
 # gpu_mem=256
 
 [pi4]
-## Enable DRM VC4 V3D driver on top of the dispmanx display stack
-dtoverlay=vc4-fkms-v3d
-max_framebuffers=2
 ## Do not use more than 256Mb on Pi Model 4, it uses its own Management.
 gpu_mem=256
 


### PR DESCRIPTION
Removes dtoverlays for vc4-fkms-v3d, appears to be problematic in some setups

Signed-off-by: Stephan Wendel <me@stephanwe.de>