### PR TITLE
feat: add Orange Pi 3 and 4 LTS

### DIFF
--- a/config/armbian/default
+++ b/config/armbian/default
@@ -10,7 +10,7 @@ DOWNLOAD_BASE_URL="https://github.com/mainsail-crew/armbian-builds/releases/late
 # Base User
 BASE_ADD_USER="yes"
 BASE_USER="pi"
-BASE_USER_PASSWORD="orangepi"
+BASE_USER_PASSWORD="armbian"
 
 # Needed while building for non rpi sbc
 BASE_DISTRO="armbian"

--- a/config/armbian/default
+++ b/config/armbian/default
@@ -1,10 +1,39 @@
-export BASE_APT_CACHE=no
-export OCTOPI_INCLUDE_WIRINGPI=no
-export BASE_DISTRO=armbian
-export BASE_ROOT_PARTITION=2
-export BASE_IMAGE_RESIZEROOT=500
-export BASE_IMAGE_RASPBIAN=no
-export BASE_IMAGE_ENLARGEROOT=1000
-export BASE_ARCH=arm64
+#!/usr/bin/env bash
+# Shebang for better file detection
 
-export MODULES="base,pkgupgrade"
+# Declare Variables before exporting.
+# See https://www.shellcheck.net/wiki/SC2155
+
+# Download Base Url
+DOWNLOAD_BASE_URL="https://github.com/mainsail-crew/armbian-builds/releases/latest/download"
+
+# Base User
+BASE_ADD_USER="yes"
+BASE_USER="pi"
+BASE_USER_PASSWORD="orangepi"
+
+# Needed while building for non rpi sbc
+BASE_DISTRO="armbian"
+BASE_IMAGE_RASPBIAN="no"
+
+# partition resizing
+BASE_ROOT_PARTITION="2"
+BASE_IMAGE_ENLARGEROOT=2500
+BASE_IMAGE_RESIZEROOT=600
+# Compress not needed due compression done in workflow
+BASE_RELEASE_COMPRESS=no
+# Modules are valid for 32bit and 64bit images
+MODULES="base,pkgupgrade,armbian(mainsailos,klipper,moonraker,mainsail,timelapse,crowsnest,sonar)"
+
+# export Variables
+export DOWNLOAD_BASE_URL
+export BASE_ADD_USER
+export BASE_USER
+export BASE_USER_PASSWORD
+export BASE_DISTRO
+export BASE_IMAGE_RASPBIAN
+export BASE_ROOT_PARTITION
+export BASE_IMAGE_ENLARGEROOT
+export BASE_IMAGE_RESIZEROOT
+export BASE_RELEASE_COMPRESS
+export MODULES

--- a/config/armbian/default
+++ b/config/armbian/default
@@ -23,7 +23,7 @@ BASE_IMAGE_RESIZEROOT=600
 # Compress not needed due compression done in workflow
 BASE_RELEASE_COMPRESS=no
 # Modules are valid for 32bit and 64bit images
-MODULES="base,pkgupgrade,armbian(opiconfig,mainsailos,klipper,is_req_preinstall,moonraker,mainsail,timelapse,crowsnest,sonar)"
+MODULES="base,pkgupgrade,armbian(armbian_net,opiconfig,mainsailos,klipper,is_req_preinstall,moonraker,mainsail,timelapse,crowsnest,sonar)"
 
 # export Variables
 export DOWNLOAD_BASE_URL

--- a/config/armbian/default
+++ b/config/armbian/default
@@ -23,7 +23,7 @@ BASE_IMAGE_RESIZEROOT=600
 # Compress not needed due compression done in workflow
 BASE_RELEASE_COMPRESS=no
 # Modules are valid for 32bit and 64bit images
-MODULES="base,pkgupgrade,armbian(mainsailos,klipper,moonraker,mainsail,timelapse,crowsnest,sonar)"
+MODULES="base,pkgupgrade,armbian(opiconfig,mainsailos,klipper,is_req_preinstall,moonraker,mainsail,timelapse,crowsnest,sonar)"
 
 # export Variables
 export DOWNLOAD_BASE_URL

--- a/config/armbian/orangepi3lts
+++ b/config/armbian/orangepi3lts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Shebang for better file detection
+# shellcheck enable=require-variable-braces
+
+BASE_ARCH="arm64"
+
+# Image source
+DOWNLOAD_URL_CHECKSUM="${DOWNLOAD_BASE_URL}/orangepi3_lts.img.xz.sha256"
+DOWNLOAD_URL_IMAGE="${DOWNLOAD_BASE_URL}/orangepi3_lts.img.xz"
+
+# export Variables
+export BASE_ARCH
+export DOWNLOAD_URL_CHECKSUM
+export DOWNLOAD_URL_IMAGE

--- a/config/armbian/orangepi3lts
+++ b/config/armbian/orangepi3lts
@@ -5,8 +5,8 @@
 BASE_ARCH="arm64"
 
 # Image source
-DOWNLOAD_URL_CHECKSUM="${DOWNLOAD_BASE_URL}/orangepi3_lts.img.xz.sha256"
-DOWNLOAD_URL_IMAGE="${DOWNLOAD_BASE_URL}/orangepi3_lts.img.xz"
+DOWNLOAD_URL_CHECKSUM="${DOWNLOAD_BASE_URL}/armbian-orangepi3_lts.img.xz.sha256"
+DOWNLOAD_URL_IMAGE="${DOWNLOAD_BASE_URL}/armbian-orangepi3_lts.img.xz"
 
 # export Variables
 export BASE_ARCH

--- a/config/armbian/orangepi4lts
+++ b/config/armbian/orangepi4lts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Shebang for better file detection
+# shellcheck enable=require-variable-braces
+
+BASE_ARCH="arm64"
+
+# Image source
+DOWNLOAD_URL_CHECKSUM="${DOWNLOAD_BASE_URL}/orangepi4_lts.img.xz.sha256"
+DOWNLOAD_URL_IMAGE="${DOWNLOAD_BASE_URL}/orangepi4_lts.img.xz"
+
+# export Variables
+export BASE_ARCH
+export DOWNLOAD_URL_CHECKSUM
+export DOWNLOAD_URL_IMAGE

--- a/config/armbian/orangepi4lts
+++ b/config/armbian/orangepi4lts
@@ -5,8 +5,8 @@
 BASE_ARCH="arm64"
 
 # Image source
-DOWNLOAD_URL_CHECKSUM="${DOWNLOAD_BASE_URL}/orangepi4_lts.img.xz.sha256"
-DOWNLOAD_URL_IMAGE="${DOWNLOAD_BASE_URL}/orangepi4_lts.img.xz"
+DOWNLOAD_URL_CHECKSUM="${DOWNLOAD_BASE_URL}/armbian-orangepi4_lts.img.xz.sha256"
+DOWNLOAD_URL_IMAGE="${DOWNLOAD_BASE_URL}/armbian-orangepi4_lts.img.xz"
 
 # export Variables
 export BASE_ARCH

--- a/src/modules/armbian_net/config
+++ b/src/modules/armbian_net/config
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#Shebang for better file detection
+#### mainsail module
+####
+#### Written by Stephan Wendel aka KwadFan <me@stephanwe.de>
+#### Copyright 2023 - till today
+#### https://github.com/mainsail-crew/MainsailOS
+####
+#### This File is distributed under GPLv3
+####
+
+# shellcheck disable=all
+
+[ -n "$ARMBIAN_NET_FIRSTRUN_FILE" ] || ARMBIAN_NET_FIRSTRUN_FILE="/boot/armbian_first_run.txt.template"
+[ -n "$ARMBIAN_NET_FIRSTRUN_SCRIPT" ] || ARMBIAN_NET_FIRSTRUN_SCRIPT="/usr/lib/armbian/armbian-firstrun-config"
+[ -n "$ARMBIAN_NET_NC_PATH" ] || ARMBIAN_NET_NC_PATH="/usr/local/bin/network-configurator"

--- a/src/modules/armbian_net/filesystem/root/boot/network_config.txt.template
+++ b/src/modules/armbian_net/filesystem/root/boot/network_config.txt.template
@@ -1,0 +1,49 @@
+#-----------------------------------------------------------------
+#
+# MainsailOS (armbian edition) Network Configuration
+# Set optional end user configuration
+#    - Rename this file from /boot/network_config.txt.template to /boot/network_config.txt
+#    - Settings below will be applied every time you reboot your machine.
+# Be aware, old configurations will be deleted!
+#
+# This file is based on work of the armbian developer team
+# https://github.com/armbian/build/blob/master/packages/bsp/armbian_first_run.txt.template
+#-----------------------------------------------------------------
+
+#-----------------------------------------------------------------
+# General:
+# 1 = delete this file, after first run setup is completed.
+
+NC_general_delete_this_file_after_completion=1
+
+#-----------------------------------------------------------------
+#Networking:
+# Change default network settings
+# Set to 1 to apply any network related settings below
+
+NC_net_change_defaults=0
+
+# Enable WiFi or Ethernet.
+# NB: If both are enabled, WiFi will take priority and Ethernet will be disabled.
+
+NC_net_ethernet_enabled=1
+NC_net_wifi_enabled=0
+
+#Enter your WiFi creds
+# SECURITY WARN: Your wifi keys will be stored in plaintext, no encryption.
+
+NC_net_wifi_ssid='MySSID'
+NC_net_wifi_key='MyWiFiKEY'
+
+# Country code to enable power ratings and channels for your country. eg: GB US DE | https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+
+NC_net_wifi_countrycode='GB'
+
+# If you want to use a static ip, set it here
+
+NC_net_use_static=0
+NC_net_static_ip='192.168.0.100'
+NC_net_static_mask='255.255.255.0'
+NC_net_static_gateway='192.168.0.1'
+NC_net_static_dns='8.8.8.8 8.8.4.4' # Two entries max, seperated by a space.
+#-----------------------------------------------------------------

--- a/src/modules/armbian_net/filesystem/root/etc/systemd/system/network-configurator.service
+++ b/src/modules/armbian_net/filesystem/root/etc/systemd/system/network-configurator.service
@@ -1,0 +1,20 @@
+# MainsailOS network-configurator
+# This service will run in parallel with other services
+# This is based on
+# https://github.com/armbian/build/blob/master/packages/bsp/common/lib/systemd/system/armbian-firstrun-config.service
+
+
+[Unit]
+Description=MainsailOS network configurator
+Wants=network-online.target
+After=network.target network-online.target
+ConditionPathExists=/boot/network_config.txt
+
+[Service]
+Type=idle
+RemainAfterExit=yes
+ExecStart=/usr/lib/armbian/armbian-firstrun-config
+TimeoutStartSec=2min
+
+[Install]
+WantedBy=multi-user.target

--- a/src/modules/armbian_net/filesystem/root/etc/systemd/system/network-configurator.service
+++ b/src/modules/armbian_net/filesystem/root/etc/systemd/system/network-configurator.service
@@ -13,7 +13,7 @@ ConditionPathExists=/boot/network_config.txt
 [Service]
 Type=idle
 RemainAfterExit=yes
-ExecStart=/usr/lib/armbian/armbian-firstrun-config
+ExecStart=/usr/local/bin/network-configurator
 TimeoutStartSec=2min
 
 [Install]

--- a/src/modules/armbian_net/start_chroot_script
+++ b/src/modules/armbian_net/start_chroot_script
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# MainsailOS network configurator for armbian images
+# written by Stephan Wendel aka KwadFan
+# <me@stephanwe.de>
+# GPL V3
+########
+
+# shellcheck enable=require-variable-braces
+
+# Description:
+# This file installs a service based on armbians armbian_firstrun_config
+# The original work is done by the armbian developer's team
+# sources of files can be found here: https://github.com/armbian/build
+
+# Source error handling, leave this in place
+set -Ee
+
+# Source CustomPIOS common.sh
+# shellcheck disable=SC1091
+source /common.sh
+install_cleanup_trap
+
+
+## Step 1: Install files
+unpack filesystem/root / root
+
+## Step 2: remove original template
+if [[ -f "${ARMBIAN_NET_FIRSTRUN_FILE}" ]]; then
+    sudo rm -rf "${ARMBIAN_NET_FIRSTRUN_FILE}"
+fi
+
+## Step 3: Disable first run service
+systemctl_if_exists disable armbian-firstrun-config.service
+
+## Step 4: Copy original script to /usr/local/bin/network-configurator
+if [[ -f "${ARMBIAN_NET_FIRSTRUN_SCRIPT}" ]]; then
+    sudo cp -p "${ARMBIAN_NET_FIRSTRUN_SCRIPT}" "${ARMBIAN_NET_NC_PATH}"
+fi
+
+## Step 5: patch /usr/local/bin/network-configurator
+if [[ -f "${ARMBIAN_NET_NC_PATH}" ]]; then
+    ### Substep 1: replace any amrbian_first_run.txt with network_config.txt
+    sed -i 's|armbian_first_run.txt|network_config.txt|g' "${ARMBIAN_NET_NC_PATH}"
+    ### Substep 2: replace any FR* Variable name with NC*
+    sed -i 's|FR|NC|g' "${ARMBIAN_NET_NC_PATH}"
+    ### Supstep 3: Rename function
+    sed -i 's|do_firstrun_automated_user_configuration|do_network_configuration|g' "${ARMBIAN_NET_NC_PATH}"
+    ### Substep 4: Add a patch note
+    sed -i '8 i \\n\# This is a patched version of armbian-firstrun-config for MainsailOS' "${ARMBIAN_NET_NC_PATH}"
+    sed -i '10 i # Original located at /usr/lib/armbian/armbian-firstrun-config' "${ARMBIAN_NET_NC_PATH}"
+    sed -i '11 i # Changes made by https:\/\/github.com/mainsail-crew' "${ARMBIAN_NET_NC_PATH}"
+fi
+
+## Step 6: Enable systemd service
+systemctl_if_exists enable network-configurator.service

--- a/src/modules/is_req_preinstall/config
+++ b/src/modules/is_req_preinstall/config
@@ -4,4 +4,4 @@
 [ -n "$IS_REQ_PREINSTALL_DEPS" ] || IS_REQ_PREINSTALL_DEPS="python3-numpy python3-matplotlib \
 libatlas3-base libatlas-base-dev libgfortran5"
 [ -n "$IS_REQ_PREINSTALL_PIP" ] || IS_REQ_PREINSTALL_PIP="numpy<=1.23.4"
-[ -n "$IS_REQ_PREINSTALL_CFG_FILE" ] || IS_REQ_PREINSTALL_CFG_FILE="/boot/config.txt"
+

--- a/src/modules/klipper/config
+++ b/src/modules/klipper/config
@@ -21,7 +21,7 @@
 [ -n "$KLIPPER_DEPS" ] || KLIPPER_DEPS="git virtualenv python3-dev \
 python3-matplotlib libffi-dev build-essential libncurses-dev libusb-dev \
 avrdude gcc-avr binutils-avr avr-libc stm32flash dfu-util libnewlib-arm-none-eabi \
-gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0-0 libusb-1.0-0-dev"
+gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0-0 libusb-1.0-0-dev pkg-config"
 
 [ -n "$KLIPPER_USER_GROUPS" ] || KLIPPER_USER_GROUPS="tty,dialout"
 

--- a/src/modules/opiconfig/config
+++ b/src/modules/opiconfig/config
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#### opiconfig - OrangePi Configuration Module
+####
+#### Written by Stephan Wendel aka KwadFan <me@stephanwe.de>
+#### Copyright 2021
+#### https://github.com/mainsail-crew/MainsailOS
+####
+#### This File is distributed under GPLv3
+####
+
+# Shebang for better file detection
+# shellcheck disable=all
+
+[ -n "$OPICONFIG_CONFIG_TXT_FILE" ] || OPICONFIG_CONFIG_TXT_FILE="/boot/armbianEnv.txt"
+[ -n "$OPICONFIG_CONFIG_BAK_FILE" ] || OPICONFIG_CONFIG_BAK_FILE="/boot/armbianEnv.txt.backup"
+[ -n "$OPICONFIG_MODULES_FILE" ] || OPICONFIG_MODULES_FILE="/etc/modules"

--- a/src/modules/opiconfig/start_chroot_script
+++ b/src/modules/opiconfig/start_chroot_script
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#### opiconfig - OrangePi Configuration Module
+####
+#### Written by Stephan Wendel aka KwadFan <me@stephanwe.de>
+#### Copyright 2021
+#### https://github.com/mainsail-crew/MainsailOS
+####
+#### This File is distributed under GPLv3
+####
+
+#### NOTE: This module has to be used after armbian module!!!
+
+# shellcheck enable=require-variable-braces
+
+## Source error handling, leave this in place
+set -Ee
+
+# Set DEBIAN_FRONTEND to noninteractive
+if [[ "${DEBIAN_FRONTEND}" != "noninteractive" ]]; then
+    export DEBIAN_FRONTEND=noninteractive
+fi
+
+## Source CustomPIOS common.sh
+# shellcheck disable=SC1091
+source /common.sh
+install_cleanup_trap
+
+### Helper func
+is_board_type() {
+    local board releasefile
+    board=""
+    releasefile="/etc/armbian-release-info.txt"
+    if [[ -f "${releasefile}" ]]; then
+        board="$(grep "BOARD=" "${releasefile}" | cut -d'=' -f2)"
+    fi
+    echo "${board}"
+}
+
+
+# Step 1: Copy default config to backup file
+cp "${OPICONFIG_CONFIG_TXT_FILE}" "${OPICONFIG_CONFIG_BAK_FILE}"
+
+# Step 2: Enable SPI in armbianEnv.txt depending on device
+
+## OrangePi 3 LTS
+if [[ "$(is_board_type)" == "orangepi3-lts" ]]; then
+    echo "overlays=spi-spidev1" >> "${OPICONFIG_CONFIG_TXT_FILE}"
+fi
+
+## OrangePi 4 LTS
+if [[ "$(is_board_type)" == "orangepi4-lts" ]]; then
+    echo "overlays=spi-spidev" >> "${OPICONFIG_CONFIG_TXT_FILE}"
+    echo "param_spidev_spi_bus=1" >> "${OPICONFIG_CONFIG_TXT_FILE}"
+fi
+
+# Step 3: add spi-dev module to /etc/modules
+echo "param_spidev_spi_bus=1" >> "${OPICONFIG_MODULES_FILE}"

--- a/src/modules/opiconfig/start_chroot_script
+++ b/src/modules/opiconfig/start_chroot_script
@@ -37,6 +37,8 @@ is_board_type() {
 }
 
 
+echo_green "Enable SPI interface on Orange Pi SBC's ..."
+
 # Step 1: Copy default config to backup file
 cp "${OPICONFIG_CONFIG_TXT_FILE}" "${OPICONFIG_CONFIG_BAK_FILE}"
 
@@ -55,3 +57,5 @@ fi
 
 # Step 3: add spi-dev module to /etc/modules
 echo "param_spidev_spi_bus=1" >> "${OPICONFIG_MODULES_FILE}"
+
+echo_green "Enable SPI interface on Orange Pi SBC's ... DONE!"

--- a/src/modules/opiconfig/start_chroot_script
+++ b/src/modules/opiconfig/start_chroot_script
@@ -56,6 +56,6 @@ if [[ "$(is_board_type)" == "orangepi4-lts" ]]; then
 fi
 
 # Step 3: add spi-dev module to /etc/modules
-echo "param_spidev_spi_bus=1" >> "${OPICONFIG_MODULES_FILE}"
+echo "spi-dev" >> "${OPICONFIG_MODULES_FILE}"
 
 echo_green "Enable SPI interface on Orange Pi SBC's ... DONE!"


### PR DESCRIPTION
This builds an basic Image for

Orange Pi 3 LTS and 4 LTS

Includes:
- mainsail
- klipper
- moonraker
- timelapse
- crowsnest
- sonar
- Input Shaper PreInstall
- Hardware preconfiguration

Signed-off-by: Stephan Wendel <me@stephanwe.de>