### PR TITLE
feat: add Orangepi zero 1 (only a test)

### DIFF
--- a/config/armbian/default
+++ b/config/armbian/default
@@ -1,10 +1,39 @@
-export BASE_APT_CACHE=no
-export OCTOPI_INCLUDE_WIRINGPI=no
-export BASE_DISTRO=armbian
-export BASE_ROOT_PARTITION=2
-export BASE_IMAGE_RESIZEROOT=500
-export BASE_IMAGE_RASPBIAN=no
-export BASE_IMAGE_ENLARGEROOT=1000
-export BASE_ARCH=arm64
+#!/usr/bin/env bash
+# Shebang for better file detection
 
-export MODULES="base,pkgupgrade"
+# Declare Variables before exporting.
+# See https://www.shellcheck.net/wiki/SC2155
+
+# Download Base Url
+DOWNLOAD_BASE_URL="https://github.com/mainsail-crew/armbian-builds/releases/latest/download"
+
+# Base User
+BASE_ADD_USER="yes"
+BASE_USER="pi"
+BASE_USER_PASSWORD="orangepi"
+
+# Needed while building for non rpi sbc
+BASE_DISTRO="armbian"
+BASE_IMAGE_RASPBIAN="no"
+
+# partition resizing
+BASE_ROOT_PARTITION="2"
+BASE_IMAGE_ENLARGEROOT=2500
+BASE_IMAGE_RESIZEROOT=600
+# Compress not needed due compression done in workflow
+BASE_RELEASE_COMPRESS=no
+# Modules are valid for 32bit and 64bit images
+MODULES="base,pkgupgrade,armbian(mainsailos,klipper,moonraker,mainsail,timelapse,crowsnest,sonar)"
+
+# export Variables
+export DOWNLOAD_BASE_URL
+export BASE_ADD_USER
+export BASE_USER
+export BASE_USER_PASSWORD
+export BASE_DISTRO
+export BASE_IMAGE_RASPBIAN
+export BASE_ROOT_PARTITION
+export BASE_IMAGE_ENLARGEROOT
+export BASE_IMAGE_RESIZEROOT
+export BASE_RELEASE_COMPRESS
+export MODULES

--- a/config/armbian/orangepi3lts
+++ b/config/armbian/orangepi3lts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Shebang for better file detection
+# shellcheck enable=require-variable-braces
+
+BASE_ARCH="arm64"
+
+# Image source
+DOWNLOAD_URL_CHECKSUM="${DOWNLOAD_BASE_URL}/orangepi3_lts.img.xz.sha256"
+DOWNLOAD_URL_IMAGE="${DOWNLOAD_BASE_URL}/orangepi3_lts.img.xz"
+
+# export Variables
+export BASE_ARCH
+export DOWNLOAD_URL_CHECKSUM
+export DOWNLOAD_URL_IMAGE

--- a/config/armbian/orangepi4lts
+++ b/config/armbian/orangepi4lts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Shebang for better file detection
+# shellcheck enable=require-variable-braces
+
+BASE_ARCH="arm64"
+
+# Image source
+DOWNLOAD_URL_CHECKSUM="${DOWNLOAD_BASE_URL}/orangepi4_lts.img.xz.sha256"
+DOWNLOAD_URL_IMAGE="${DOWNLOAD_BASE_URL}/orangepi4_lts.img.xz"
+
+# export Variables
+export BASE_ARCH
+export DOWNLOAD_URL_CHECKSUM
+export DOWNLOAD_URL_IMAGE

--- a/config/armbian/orangepizero1
+++ b/config/armbian/orangepizero1
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Shebang for better file detection
+# shellcheck enable=require-variable-braces
+
+BASE_ARCH="arm64"
+
+# Image source
+DOWNLOAD_URL_CHECKSUM="${DOWNLOAD_BASE_URL}/orangepi_zero.img.xz.sha256"
+DOWNLOAD_URL_IMAGE="${DOWNLOAD_BASE_URL}/orangepi_zero.img.xz"
+
+# export Variables
+export BASE_ARCH
+export DOWNLOAD_URL_CHECKSUM
+export DOWNLOAD_URL_IMAGE


### PR DESCRIPTION
This builds an basic Image for

Orange Pi 3 LTS and 4 LTS

Includes:
- mainsail
- klipper
- moonraker
- timelapse
- crowsnest
- sonar

Missing:

- Input Shaper PreInstall
- Hardware preconfiguration

Signed-off-by: Stephan Wendel <me@stephanwe.de>