### PR TITLE
fix: fix rpi-imager json value format for int values

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -247,9 +247,9 @@ jobs:
               icon,
               init_format,
               release_date,
-              extract_size,
+              extract_size: parseInt(extract_size),
               extract_sha256,
-              image_download_size,
+              image_download_size: parseInt(image_download_size),
               image_download_sha256
             })
 


### PR DESCRIPTION
this PR fix the rpi-imager json workflow to parse extract_size & image_download_size as an integer