### PR TITLE
fix: fix udev for version 'rp1+deb11u2'

### DIFF
--- a/patches/Readme.md
+++ b/patches/Readme.md
@@ -10,7 +10,7 @@ _**DO NOT RUN THIS ON LATER VERSIONS!!!**_
 
 ### Usage:
 
-`curl -sSL https://raw.githubusercontent.com/mainsail-crew/MainsailOS/develop/patches/patch.sh | bash`
+`curl -sSL https://raw.githubusercontent.com/mainsail-crew/MainsailOS/develop/patches/patch101.sh | bash`
 
 This will ask you for sudo password!
 
@@ -18,7 +18,7 @@ In most cases a reboot is required!
 
 ## udev-fix.sh
 
-This is intended to patch udev rules which has a Bug in udev package (version: 247.3-7+deb11u2).
+This is intended to patch udev rules which has a Bug in udev package (version: 247.3-7+deb11u2 or 247.3-7+rpi1+deb11u2).
 Which does not create `/dev/serial/by-id` symlinks for your MCU.\
 For further details see:
 

--- a/patches/udev-fix.sh
+++ b/patches/udev-fix.sh
@@ -74,7 +74,7 @@ print_footer(){
 # Patch Funcs
 
 patch_udev(){
-    if [[ -n "${UDEV_PKG_VERSION}" ]] && [[ "${UDEV_PKG_VERSION}" = "247.3-7+deb11u2" ]]; then
+    if [[ -n "${UDEV_PKG_VERSION}" ]] && [[ "${UDEV_PKG_VERSION}" =~ "deb11u2" ]]; then
         echo_red "'udev' version: ${UDEV_PKG_VERSION}, is affected by bug ..."
         echo_green "Install patched udev rule from systemd git repository ..."
         curl -sSL "${UDEV_FIX_RAW_RULE_FILE}" > "${UDEV_FIX_TMP_FILE}"

--- a/src/modules/udev_fix/start_chroot_script
+++ b/src/modules/udev_fix/start_chroot_script
@@ -38,7 +38,7 @@ fi
 # Step 2: Fix broken udev (remove after debian releases patch)
 UDEV_PKG_VERSION="$(dpkg-query -s udev | grep "Version" | sed 's/Version\: //')"
 
-if [[ -n "${UDEV_PKG_VERSION}" ]] && [[ "${UDEV_PKG_VERSION}" = "247.3-7+deb11u2" ]]; then
+if [[ -n "${UDEV_PKG_VERSION}" ]] && [[ "${UDEV_PKG_VERSION}" =~ "deb11u2" ]]; then
     echo_red "'udev' version: ${UDEV_PKG_VERSION}, is affected by bug ..."
     echo_green "Install patched udev rule from systemd git repository ..."
     curl -sSL "${UDEV_FIX_RAW_RULE_FILE}" > "${UDEV_FIX_OUTPUT_FILE}"


### PR DESCRIPTION
This is needed to also patch if version is from raspberry which is named '247.3-7+rpi1+deb11u2'

Also includes fix for typo in previous patch