### PR TITLE
chore: update download urls for armbian & orangepi

### DIFF
--- a/config/armbian/orangepi3lts
+++ b/config/armbian/orangepi3lts
@@ -5,8 +5,8 @@
 BASE_ARCH="arm64"
 
 # Image source
-DOWNLOAD_URL_CHECKSUM="${DOWNLOAD_BASE_URL}/armbian-orangepi3_lts.img.xz.sha256"
-DOWNLOAD_URL_IMAGE="${DOWNLOAD_BASE_URL}/armbian-orangepi3_lts.img.xz"
+DOWNLOAD_URL_CHECKSUM="${DOWNLOAD_BASE_URL}/armbian-orangepi3_lts_bullseye.img.xz.sha256"
+DOWNLOAD_URL_IMAGE="${DOWNLOAD_BASE_URL}/armbian-orangepi3_lts_bullseye.img.xz"
 
 # export Variables
 export BASE_ARCH

--- a/config/armbian/orangepi4lts
+++ b/config/armbian/orangepi4lts
@@ -5,8 +5,8 @@
 BASE_ARCH="arm64"
 
 # Image source
-DOWNLOAD_URL_CHECKSUM="${DOWNLOAD_BASE_URL}/armbian-orangepi4_lts.img.xz.sha256"
-DOWNLOAD_URL_IMAGE="${DOWNLOAD_BASE_URL}/armbian-orangepi4_lts.img.xz"
+DOWNLOAD_URL_CHECKSUM="${DOWNLOAD_BASE_URL}/armbian-orangepi4_lts_bullseye.img.xz.sha256"
+DOWNLOAD_URL_IMAGE="${DOWNLOAD_BASE_URL}/armbian-orangepi4_lts_bullseye.img.xz"
 
 # export Variables
 export BASE_ARCH

--- a/config/orangepi/orangepi_zero2
+++ b/config/orangepi/orangepi_zero2
@@ -5,8 +5,8 @@
 BASE_ARCH="arm64"
 
 # Image source
-DOWNLOAD_URL_CHECKSUM="${DOWNLOAD_BASE_URL}/orangepi-orangepi_zero2.img.xz.sha256"
-DOWNLOAD_URL_IMAGE="${DOWNLOAD_BASE_URL}/orangepi-orangepi_zero2.img.xz"
+DOWNLOAD_URL_CHECKSUM="${DOWNLOAD_BASE_URL}/orangepi-orangepi_zero2_bullseye.img.xz.sha256"
+DOWNLOAD_URL_IMAGE="${DOWNLOAD_BASE_URL}/orangepi-orangepi_zero2_bullseye.img.xz"
 
 # export Variables
 export BASE_ARCH


### PR DESCRIPTION
This PR only adds _bullseye in the download URLs, because I added Bookworm images in the armbian-builds repo.