### PR TITLE
fix: fix wifi connectivity

### DIFF
--- a/config/armbian/default
+++ b/config/armbian/default
@@ -23,7 +23,7 @@ BASE_IMAGE_RESIZEROOT=600
 # Compress not needed due compression done in workflow
 BASE_RELEASE_COMPRESS=no
 # Modules are valid for 32bit and 64bit images
-MODULES="base,udev_fix,armbian(armbian_net,mainsailos,klipper,is_req_preinstall,moonraker,mainsail,timelapse,crowsnest,sonar)"
+MODULES="base,pkgupgrade,udev_fix,armbian(armbian_net,mainsailos,klipper,is_req_preinstall,moonraker,mainsail,timelapse,crowsnest,sonar)"
 
 # export Variables
 export DOWNLOAD_BASE_URL

--- a/src/modules/armbian_net/config
+++ b/src/modules/armbian_net/config
@@ -14,3 +14,4 @@
 [[ -n "$ARMBIAN_NET_FIRSTRUN_FILE" ]] || ARMBIAN_NET_FIRSTRUN_FILE="/boot/armbian_first_run.txt.template"
 [[ -n "$ARMBIAN_NET_FIRSTRUN_SCRIPT" ]] || ARMBIAN_NET_FIRSTRUN_SCRIPT="/usr/lib/armbian/armbian-firstrun-config"
 [[ -n "$ARMBIAN_NET_NC_PATH" ]] || ARMBIAN_NET_NC_PATH="/usr/local/bin/network-configurator"
+[[ -n "$ARMBIAN_NET_DEPS" ]] || ARMBIAN_NET_DEPS="net-tools"

--- a/src/modules/armbian_net/start_chroot_script
+++ b/src/modules/armbian_net/start_chroot_script
@@ -28,6 +28,11 @@ install_cleanup_trap
 unpack filesystem/root / root
 ## END
 
+## Step 1.1: Install Depedencies
+### Needed to patch 'network_configurator'
+# shellcheck disable=SC2086
+check_install_pkgs ${ARMBIAN_NET_DEPS}
+
 ## Step 2: remove original template
 if [[ -f "${ARMBIAN_NET_FIRSTRUN_FILE}" ]]; then
     sudo rm -rf "${ARMBIAN_NET_FIRSTRUN_FILE}"


### PR DESCRIPTION
This should fix not working network configuration via `network_config.txt`

The script has changed by armbian but misses the crutial package `net-tools`.

Also some kernel versions on Orange Pi 3 LTS models drops wifi interface.
This is fixed by kernel 6.1.53. To get that kernel I reimplemented the `pkgupgrade`module for armbian images.
