### PR TITLE
fix: fix 'is_board_type' function

### DIFF
--- a/src/modules/armbian/start_chroot_script
+++ b/src/modules/armbian/start_chroot_script
@@ -21,7 +21,7 @@ install_cleanup_trap
 is_board_type() {
     local board releasefile
     board=""
-    releasefile="/etc/armbian-release-info.txt"
+    releasefile="/etc/armbian-release"
     if [[ -f "${releasefile}" ]]; then
         board="$(grep "BOARD=" "${releasefile}" | cut -d'=' -f2)"
     fi

--- a/src/modules/orangepi/start_chroot_script
+++ b/src/modules/orangepi/start_chroot_script
@@ -28,7 +28,7 @@ install_cleanup_trap
 is_board_type() {
     local board releasefile
     board=""
-    releasefile="/etc/orangepi-release-info.txt"
+    releasefile="/etc/orangepi-release"
     if [[ -f "${releasefile}" ]]; then
         board="$(grep "BOARD=" "${releasefile}" | cut -d'=' -f2)"
     fi


### PR DESCRIPTION
Since we applied PR #241 and #242,
this function always doesnt give the right value,
which leads to unwanted behaviour in enabling SPI during build.

As we no longer rename the release file,
we have to use its original location in '/etc/armbian-release' ( Or '/etc/orangepi-release' if Opi Image is used )