### PR TITLE
fix: fix Torrent and Checksum download URLs

### DIFF
--- a/config/raspberry/rpi32
+++ b/config/raspberry/rpi32
@@ -4,8 +4,13 @@
 # Declare Variables before exporting.
 # See https://www.shellcheck.net/wiki/SC2155
 
-DOWNLOAD_URL_CHECKSUM="https://downloads.raspberrypi.org/raspios_lite_armhf_latest.sha256"
-DOWNLOAD_URL_IMAGE="https://downloads.raspberrypi.org/raspios_lite_armhf_latest.torrent"
+# Keep for Bookworm template
+# DOWNLOAD_URL_CHECKSUM="https://downloads.raspberrypi.org/raspios_lite_armhf_latest.sha256"
+# DOWNLOAD_URL_IMAGE="https://downloads.raspberrypi.org/raspios_lite_armhf_latest.torrent"
+
+# New locations after Bullseye turned into 'oldstable'
+DOWNLOAD_URL_CHECKSUM="https://downloads.raspberrypi.com/raspios_oldstable_lite_armhf/images/raspios_oldstable_lite_armhf-2023-10-10/2023-05-03-raspios-bullseye-armhf-lite.img.xz.sha256"
+DOWNLOAD_URL_IMAGE="https://downloads.raspberrypi.com/raspios_oldstable_lite_armhf/images/raspios_oldstable_lite_armhf-2023-10-10/2023-05-03-raspios-bullseye-armhf-lite.img.xz.torrent"
 
 export DOWNLOAD_URL_CHECKSUM
 export DOWNLOAD_URL_IMAGE

--- a/config/raspberry/rpi64
+++ b/config/raspberry/rpi64
@@ -6,9 +6,13 @@
 
 BASE_ARCH="arm64"
 
-DOWNLOAD_URL_CHECKSUM="https://downloads.raspberrypi.org/raspios_lite_arm64_latest.sha256"
-DOWNLOAD_URL_IMAGE="https://downloads.raspberrypi.org/raspios_lite_arm64_latest.torrent"
+# Keep for Bookworm template
+# DOWNLOAD_URL_CHECKSUM="https://downloads.raspberrypi.org/raspios_lite_arm64_latest.sha256"
+# DOWNLOAD_URL_IMAGE="https://downloads.raspberrypi.org/raspios_lite_arm64_latest.torrent"
 
+# New locations after Bullseye turned into 'oldstable'
+DOWNLOAD_URL_CHECKSUM="https://downloads.raspberrypi.com/raspios_oldstable_lite_arm64/images/raspios_oldstable_lite_arm64-2023-10-10/2023-05-03-raspios-bullseye-arm64-lite.img.xz.sha256"
+DOWNLOAD_URL_IMAGE="https://downloads.raspberrypi.com/raspios_oldstable_lite_arm64/images/raspios_oldstable_lite_arm64-2023-10-10/2023-05-03-raspios-bullseye-arm64-lite.img.xz.torrent"
 
 
 # export variables


### PR DESCRIPTION
After Bullseye images moved to 'oldstable' branch, we need to alter the URLs to 'legacy' images and checksums