### PR TITLE
fix: removing 'klippy' alias

### DIFF
--- a/src/modules/klipper/filesystem/root/etc/systemd/system/klipper.service
+++ b/src/modules/klipper/filesystem/root/etc/systemd/system/klipper.service
@@ -6,7 +6,6 @@ Before=moonraker.service
 Wants=udev.target
 
 [Install]
-Alias=klippy
 WantedBy=multi-user.target
 
 [Service]


### PR DESCRIPTION
Seems the used alias, which is uneccessary at all, leads to a failing build in some configurations.

This should fix #245