### PR TITLE
Update start_chroot_script to create custom /etc/os-release file

### DIFF
--- a/src/modules/mainsailos/start_chroot_script
+++ b/src/modules/mainsailos/start_chroot_script
@@ -31,6 +31,7 @@ function get_parent {
 }
 
 echo "${DIST_NAME} release ${DIST_VERSION} ($(get_parent))" > /etc/"${DIST_NAME,,}"-release
+echo "PRETTY_NAME="${DIST_NAME} release ${DIST_VERSION} ($(get_parent))" \nNAME="${DIST_NAME}" \nVERSION_ID="${DIST_VERSION}" \nVERSION="${DIST_VERSION} ($(get_parent)" \nVERSION_CODENAME=($(get_parent)) \nID=MainsailOS \nID_LIKE=debian  \nHOME_URL="https://www.debian.org/" \nSUPPORT_URL="https://www.debian.org/support" \nBUG_REPORT_URL="https://bugs.debian.org/" \nLOGO="MainsailOS-logo" \nANSI_COLOR="0;31" \nVENDOR_NAME="mainsail-crew" \nVENDOR_URL="https://docs.mainsail.xyz/" \nDEFAULT_HOSTNAME="mainsail"" > /etc/os-release
 ## END Step 1
 
 ## Step 2: Fake release file

--- a/src/modules/mainsailos/start_chroot_script
+++ b/src/modules/mainsailos/start_chroot_script
@@ -31,7 +31,7 @@ function get_parent {
 }
 
 echo "${DIST_NAME} release ${DIST_VERSION} ($(get_parent))" > /etc/"${DIST_NAME,,}"-release
-echo "PRETTY_NAME="${DIST_NAME} release ${DIST_VERSION} ($(get_parent))" \nNAME="${DIST_NAME}" \nVERSION_ID="${DIST_VERSION}" \nVERSION="${DIST_VERSION} ($(get_parent)" \nVERSION_CODENAME=($(get_parent)) \nID=MainsailOS \nID_LIKE=debian  \nHOME_URL="https://www.debian.org/" \nSUPPORT_URL="https://www.debian.org/support" \nBUG_REPORT_URL="https://bugs.debian.org/" \nLOGO="MainsailOS-logo" \nANSI_COLOR="0;31" \nVENDOR_NAME="mainsail-crew" \nVENDOR_URL="https://docs.mainsail.xyz/" \nDEFAULT_HOSTNAME="mainsail"" > /etc/os-release
+echo "PRETTY_NAME="${DIST_NAME} release ${DIST_VERSION} ($(get_parent))" \nNAME="${DIST_NAME}" \nVERSION_ID="${DIST_VERSION}" \nVERSION="${DIST_VERSION} ($(get_parent)" \nVERSION_CODENAME=($(get_parent)) \nID=MainsailOS \nID_LIKE=debian  \nHOME_URL="https://www.debian.org/" \nSUPPORT_URL="https://www.debian.org/support" \nBUG_REPORT_URL="https://bugs.debian.org/" \nANSI_COLOR="0;31" \nVENDOR_NAME="mainsail-crew" \nVENDOR_URL="https://docs.mainsail.xyz/" \nDEFAULT_HOSTNAME="mainsail"" > /etc/os-release
 ## END Step 1
 
 ## Step 2: Fake release file


### PR DESCRIPTION
new file will look something like this, if i understood start_chroot_script right.
i read the arch manpage for /etc/os-release and found out that there is a variable called ID_LIKE that takes the id of the related OS, in this case debian, so if a program does not recognise MainsailOS, it will look for ID_LIKE=debian
`PRETTY_NAME="MainsailOS 1.2.1 (bullseye)"
NAME="MainsailOS"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=MainsailOS
ID_LIKE=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
LOGO="MainsailOS-logo"
ANSI_COLOR="0;31"
VENDOR_NAME="mainsail-crew"
VENDOR_URL="https://docs.mainsail.xyz/"
DEFAULT_HOSTNAME="mainsail"`