### PR TITLE
ci: skip rpi-imager.json upload, if repository_owner isn't Mainsail-Crew

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -286,7 +286,6 @@ jobs:
 
   update-rpi-imager:
     name: Update rpi-imager json
-    if: ${{ github.repository_owner == 'Mainsail-Crew' }}
     needs: [release, build, finish]
     runs-on: ubuntu-latest
     steps:
@@ -334,6 +333,7 @@ jobs:
           mv rpi-imager.json ./upload
 
       - name: Upload to remote server
+        if: ${{ github.repository_owner == 'Mainsail-Crew' }}
         uses: SamKirkland/FTP-Deploy-Action@4.3.3
         with:
           server: ${{ secrets.OSHOST }}

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -286,6 +286,7 @@ jobs:
 
   update-rpi-imager:
     name: Update rpi-imager json
+    if: ${{ github.repository_owner == 'Mainsail-Crew' }}
     needs: [release, build, finish]
     runs-on: ubuntu-latest
     steps:
@@ -341,7 +342,7 @@ jobs:
           local-dir: ./upload/
 
   update-changelog:
-    needs: update-rpi-imager
+    needs: finish
     name: Generate changelog
     runs-on: ubuntu-latest
     steps:
@@ -359,11 +360,22 @@ jobs:
           echo "TAG_NAME=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
 
       - name: Generate a changelog
+        if: ${{ github.repository_owner == 'Mainsail-Crew' }}
         uses: orhun/git-cliff-action@v1
         id: git-cliff
         with:
           config: cliff.toml
           args: 0.5.0..${{ steps.latest_tag.outputs.TAG_NAME }}
+        env:
+          OUTPUT: ${{ github.workspace }}/CHANGELOG.md
+
+      - name: Generate a changelog
+        if: ${{ github.repository_owner != 'Mainsail-Crew' }}
+        uses: orhun/git-cliff-action@v1
+        id: git-cliff
+        with:
+          config: cliff.toml
+          args: 0.0.0..${{ steps.latest_tag.outputs.TAG_NAME }}
         env:
           OUTPUT: ${{ github.workspace }}/CHANGELOG.md
 

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -354,28 +354,23 @@ jobs:
           fetch-depth: 0
 
       - name: Get latest tag
-        id: latest_tag
+        id: get_tags
         shell: bash
         run: |
-          echo "TAG_NAME=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
+          echo "END_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
+
+          if [[ "${{ github.repository_owner }}" == "Mainsail-Crew" ]]; then
+            echo "START_TAG=0.5.0" >> $GITHUB_OUTPUT
+          else
+            echo "START_TAG=0.0.0" >> $GITHUB_OUTPUT
+          fi
 
       - name: Generate a changelog
-        if: ${{ github.repository_owner == 'Mainsail-Crew' }}
         uses: orhun/git-cliff-action@v1
         id: git-cliff
         with:
           config: cliff.toml
-          args: 0.5.0..${{ steps.latest_tag.outputs.TAG_NAME }}
-        env:
-          OUTPUT: ${{ github.workspace }}/CHANGELOG.md
-
-      - name: Generate a changelog
-        if: ${{ github.repository_owner != 'Mainsail-Crew' }}
-        uses: orhun/git-cliff-action@v1
-        id: git-cliff
-        with:
-          config: cliff.toml
-          args: 0.0.0..${{ steps.latest_tag.outputs.TAG_NAME }}
+          args: ${{ steps.get_tags.outputs.START_TAG }}..${{ steps.get_tags.outputs.END_TAG }}
         env:
           OUTPUT: ${{ github.workspace }}/CHANGELOG.md
 


### PR DESCRIPTION
This PR will skip the job "update-rpi-imager" when making a release, but the repo owner is not Mainsail-Crew.