### PR TITLE
fix: fix motd on armbian and orange pi based images

### DIFF
--- a/src/modules/armbian/filesystem/root/etc/update-motd.d/10-mainsailos
+++ b/src/modules/armbian/filesystem/root/etc/update-motd.d/10-mainsailos
@@ -16,7 +16,7 @@
 # shellcheck enable=require-variable-braces
 
 # shellcheck disable=SC1091
-[[ -f /etc/armbian-release-info.txt ]] && . /etc/armbian-release-info.txt
+[[ -f /etc/armbian-release ]] && . /etc/armbian-release
 
 if [[ -f /etc/armbian-distribution-status ]]; then
     . /etc/armbian-distribution-status

--- a/src/modules/armbian/filesystem/root/etc/update-motd.d/10-mainsailos
+++ b/src/modules/armbian/filesystem/root/etc/update-motd.d/10-mainsailos
@@ -40,6 +40,6 @@ ODROID_EXCEPTION="$(tr -d '\000' < /proc/device-tree/model | grep ODROID | grep 
 
 echo -e "\e[31m$(toilet -f big MainsailOS)\e[0m"
 echo -e "Version $(cut -d ' ' -f3 /etc/mainsailos-release), based on \
-\e[34mArmbian ${VERSION} ${DISTRIBUTION_CODENAME^}\e[0m $([[ ${BRANCH} == edge ]])"
+\e[34mArmbian ${VERSION/-trunk/} ${DISTRIBUTION_CODENAME^}\e[0m $([[ ${BRANCH} == edge ]])"
 echo -e "Running on \e[34m$(echo "${BOARD_NAME}" | sed 's/Orange Pi/OPi/' | \
 sed 's/NanoPi/NPi/' | sed 's/Banana Pi/BPi/')\e[0m with \e[34mLinux ${KERNELID}\e[0m\n"

--- a/src/modules/orangepi/filesystem/root/etc/update-motd.d/10-mainsailos
+++ b/src/modules/orangepi/filesystem/root/etc/update-motd.d/10-mainsailos
@@ -16,7 +16,7 @@
 # shellcheck enable=require-variable-braces
 
 # shellcheck disable=SC1091
-[[ -f /etc/orangepi-release-info.txt ]] && . /etc/orangepi-release-info.txt
+[[ -f /etc/orangepi-release ]] && . /etc/orangepi-release
 
 if [[ -f /etc/orangepi-distribution-status ]]; then
     . /etc/orangepi-distribution-status


### PR DESCRIPTION
Due #241 the motd will not be updated as intended.
Files are not moved as in the past, so they can not be sourced.
This leads to an empty 'version' description.

Signed-off-by: Stephan Wendel <me@stephanwe.de>