### PR TITLE
fix(ci): Fix annotations from actions

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,18 +1,18 @@
-name: 'MainsailOS/build'
-author: 'Stefan Dej'
-description: 'Build MainsailOS images'
+name: "MainsailOS/build"
+author: "Stefan Dej"
+description: "Build MainsailOS images"
 inputs:
   config:
-    description: 'Board config name'
+    description: "Board config name"
     required: true
   custompios-repository:
-    description: 'Repository for CustomPiOS'
+    description: "Repository for CustomPiOS"
     required: false
-    default: 'guysoft/CustomPiOS'
+    default: "guysoft/CustomPiOS"
   custompios-ref:
-    description: 'Branch / Tag / SHA to checkout CustomPiOS'
+    description: "Branch / Tag / SHA to checkout CustomPiOS"
     required: false
-    default: 'devel'
+    default: "devel"
 outputs:
   type:
     description: SBC type (raspberry/armbian/...)
@@ -22,7 +22,7 @@ outputs:
     value: ${{ steps.config.outputs.SBC }}
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Install Dependencies
       shell: bash
@@ -87,7 +87,7 @@ runs:
 
     - name: Cache Base Source Image
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4.0.0
       with:
         path: repository/src/image/*.img.xz
         key: base-image-${{ steps.checksum.outputs.CHECKSUM }}

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -87,7 +87,7 @@ runs:
 
     - name: Cache Base Source Image
       id: cache
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4
       with:
         path: repository/src/image/*.img.xz
         key: base-image-${{ steps.checksum.outputs.CHECKSUM }}

--- a/.github/workflows/BuildImages.yml
+++ b/.github/workflows/BuildImages.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload failed Logfile
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: failed-${{ steps.move-image.outputs.image }}.log
           path: repository/src/build.log
@@ -100,19 +100,19 @@ jobs:
           sha256sum ${{ steps.move-image.outputs.image }}.img.xz > ${{ steps.move-image.outputs.image }}.img.xz.sha256
 
       - name: Upload Compressed Image
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.move-image.outputs.image }}.img.xz
           path: ${{ steps.move-image.outputs.image }}.img.xz
 
       - name: Upload Compressed Image Checksum
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.move-image.outputs.image }}.img.xz.sha256
           path: ${{ steps.move-image.outputs.image }}.img.xz.sha256
 
       - name: Upload Image Checksum
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.move-image.outputs.image }}.img.sha256
           path: ${{ steps.move-image.outputs.image }}.img.sha256

--- a/.github/workflows/BuildImages.yml
+++ b/.github/workflows/BuildImages.yml
@@ -100,19 +100,19 @@ jobs:
           sha256sum ${{ steps.move-image.outputs.image }}.img.xz > ${{ steps.move-image.outputs.image }}.img.xz.sha256
 
       - name: Upload Compressed Image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: ${{ steps.move-image.outputs.image }}.img.xz
           path: ${{ steps.move-image.outputs.image }}.img.xz
 
       - name: Upload Compressed Image Checksum
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: ${{ steps.move-image.outputs.image }}.img.xz.sha256
           path: ${{ steps.move-image.outputs.image }}.img.xz.sha256
 
       - name: Upload Image Checksum
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: ${{ steps.move-image.outputs.image }}.img.sha256
           path: ${{ steps.move-image.outputs.image }}.img.sha256

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Upload failed Logfile
         if: failure()
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: failed-${{ steps.move-image.outputs.image }}.log
           path: repository/src/build.log

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Upload failed Logfile
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: failed-${{ steps.move-image.outputs.image }}.log
           path: repository/src/build.log


### PR DESCRIPTION
This PR fixes the annotations about 'actions/cache@v3' and 'actions/upload-artifact@v3'.
Since this particular versions use Node 16 which are marked as depricated,
We had to update to latest versions.
These are in particular 'actions/cache' in version v4.0.0 and
'actions/upload-artifact' in version v4.3.1.
These versions are shown in github marketplace if you click on 'use latest'


![annotations](https://github.com/mainsail-crew/MainsailOS/assets/43513802/e9c20599-dca6-46df-bef2-11794adb39a0)
