### PR TITLE
Feat: add OrangePi Zero 2W configuration

### DIFF
--- a/config/armbian/orangepi_zero2w
+++ b/config/armbian/orangepi_zero2w
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Shebang for better file detection
+# shellcheck enable=require-variable-braces
+
+BASE_ARCH="arm64"
+
+# Image source
+DOWNLOAD_URL_CHECKSUM="${DOWNLOAD_BASE_URL}/armbian-orangepi_zero2w_bullseye.img.xz.sha256"
+DOWNLOAD_URL_IMAGE="${DOWNLOAD_BASE_URL}/armbian-orangepi_zero2w_bullseye.img.xz"
+
+# export Variables
+export BASE_ARCH
+export DOWNLOAD_URL_CHECKSUM
+export DOWNLOAD_URL_IMAGE
+
+### JSON sniplet Setup
+### NOTE: Please see all config files for setup variables!!!
+# shellcheck disable=SC2034
+JSON_PRETTY_SBC_NAME="Orange Pi Zero2W"
+# shellcheck disable=SC2034
+JSON_SUPPORTED_SBC="orangepizero2w-64bit"


### PR DESCRIPTION
This PR adds the OrangePi Zero 2W which is very similar to the Zero 2 but with wifi and bluetooth support. The respective PR in the armbian config repository is at: https://github.com/mainsail-crew/armbian-builds/pull/59