### PR TITLE
ci: add attribute to config.yml to add "build_only" images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,11 @@ jobs:
           import os, yaml, json
           with open("config.yml", "r") as f:
               config = yaml.safe_load(f)
-          matrix = {"include": config}
+
+          # Filter out build_only configurations for release
+          release_config = [item for item in config if not item.get('build_only', False)]
+
+          matrix = {"include": release_config}
           with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
               print(f"matrix={json.dumps(matrix)}", file=fh)
 

--- a/config.yml
+++ b/config.yml
@@ -56,6 +56,26 @@
     devices:
       - "opi4-64bit"
 
+- name: armbian-orangepi4_lts-trixie
+  type: armbian
+  build_only: true
+  img_download_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi4_lts_trixie.img.xz"
+  img_hash_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi4_lts_trixie.img.xz.sha256"
+  env:
+    ARCH: arm64
+    DISTRO: armbian
+    IMAGE_ENLARGEROOT: 5000
+    MOUNT_PROC: 1
+    MOUNT_SYS: 1
+  special_modules:
+    - 20-opi-4lts-spi
+  rpi_json:
+    name: "MainsailOS $VERSION$ - Orange Pi 4 LTS (64-bit)"
+    description: "A port of Armbian with preinstalled Klipper/Moonraker/Mainsail for 3D printers"
+    icon: "https://os.mainsail.xyz/rpi-imager.png"
+    devices:
+      - "opi4-64bit"
+
 - name: armbian-orangepi3_lts-bookworm
   type: armbian
   img_download_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi3_lts_bookworm.img.xz"

--- a/config.yml
+++ b/config.yml
@@ -56,26 +56,6 @@
     devices:
       - "opi4-64bit"
 
-- name: armbian-orangepi4_lts-trixie
-  type: armbian
-  build_only: true
-  img_download_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi4_lts_trixie.img.xz"
-  img_hash_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi4_lts_trixie.img.xz.sha256"
-  env:
-    ARCH: arm64
-    DISTRO: armbian
-    IMAGE_ENLARGEROOT: 5000
-    MOUNT_PROC: 1
-    MOUNT_SYS: 1
-  special_modules:
-    - 20-opi-4lts-spi
-  rpi_json:
-    name: "MainsailOS $VERSION$ - Orange Pi 4 LTS (64-bit)"
-    description: "A port of Armbian with preinstalled Klipper/Moonraker/Mainsail for 3D printers"
-    icon: "https://os.mainsail.xyz/rpi-imager.png"
-    devices:
-      - "opi4-64bit"
-
 - name: armbian-orangepi3_lts-bookworm
   type: armbian
   img_download_url: "https://github.com/mainsail-crew/armbian-builds/releases/latest/download/armbian-orangepi3_lts_bookworm.img.xz"


### PR DESCRIPTION
This PR adds a new attribute to the `config.yml` to allow test images, which will be not released.

Just add the parameter `build_only: True` to a image definition in the `config.yml` like that:
```yaml
- name: raspberry_pi-arm64-ks-bookworm
  type: raspberry
  build_only: True
  ...
```

Images with this value will be just executed/build in the PR builds, but will be skipped during the release workflow.