### PR TITLE
fix: enable wifi per default on rpi sbcs

### DIFF
--- a/modules/raspberry/11-fix-wifi
+++ b/modules/raspberry/11-fix-wifi
@@ -21,6 +21,7 @@ source /files/00-config
 ########################################
 
 NM_STATE="/var/lib/NetworkManager/NetworkManager.state"
+CMDLINE="${BOOT_PATH}/cmdline.txt"
 
 ########################################
 # Unblock rfkill wifi                  #
@@ -45,4 +46,4 @@ fi
 sed -i \
     -e "s/\s*cfg80211.ieee80211_regdom=\S*//" \
     -e "s/\(.*\)/\1 cfg80211.ieee80211_regdom=00/" \
-    "$BOOT_PATH"/cmdline.txt
+    "${CMDLINE}"

--- a/modules/raspberry/11-fix-wifi
+++ b/modules/raspberry/11-fix-wifi
@@ -21,7 +21,6 @@ source /files/00-config
 ########################################
 
 NM_STATE="/var/lib/NetworkManager/NetworkManager.state"
-CMDLINE="${BOOT_PATH}/cmdline.txt"
 
 ########################################
 # Unblock rfkill wifi                  #
@@ -38,12 +37,3 @@ elif
 if [[ -f "$NM_STATE" ]]; then
     sed -i 's/^WirelessEnabled=.*/WirelessEnabled=true/' "$NM_STATE"
 fi
-
-########################################
-# Set Wifi to international            #
-########################################
-
-sed -i \
-    -e "s/\s*cfg80211.ieee80211_regdom=\S*//" \
-    -e "s/\(.*\)/\1 cfg80211.ieee80211_regdom=00/" \
-    "${CMDLINE}"

--- a/modules/raspberry/11-fix-wifi
+++ b/modules/raspberry/11-fix-wifi
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# this module is based on the rasp-config
+
+set -xe
+export LC_ALL=C
+
+########################################
+# Functions and Basic Configuration    #
+########################################
+
+# Load common functions and set up cleanup trap
+source /common.sh
+install_cleanup_trap
+
+# Load additional configuration (e.g., BASE_USER)
+source /files/00-config
+
+########################################
+# Configuration                        #
+########################################
+
+NM_STATE="/var/lib/NetworkManager/NetworkManager.state"
+
+########################################
+# Unblock rfkill wifi                  #
+########################################
+
+if hash rfkill 2> /dev/null; then
+    rfkill unblock wifi
+elif
+
+########################################
+# Fix Wireless State                   #
+########################################
+
+if [[ -f "$NM_STATE" ]]; then
+    sed -i 's/^WirelessEnabled=.*/WirelessEnabled=true/' "$NM_STATE"
+fi
+
+########################################
+# Set Wifi to international            #
+########################################
+
+sed -i \
+    -e "s/\s*cfg80211.ieee80211_regdom=\S*//" \
+    -e "s/\(.*\)/\1 cfg80211.ieee80211_regdom=00/" \
+    "$BOOT_PATH"/cmdline.txt

--- a/modules/raspberry/11-fix-wifi
+++ b/modules/raspberry/11-fix-wifi
@@ -28,12 +28,12 @@ NM_STATE="/var/lib/NetworkManager/NetworkManager.state"
 
 if hash rfkill 2> /dev/null; then
     rfkill unblock wifi
-elif
+fi
 
 ########################################
 # Fix Wireless State                   #
 ########################################
 
 if [[ -f "$NM_STATE" ]]; then
-    sed -i 's/^WirelessEnabled=.*/WirelessEnabled=true/g' "$NM_STATE"
+    sed -i 's/^WirelessEnabled=.*/WirelessEnabled=true/' "$NM_STATE"
 fi

--- a/modules/raspberry/11-fix-wifi
+++ b/modules/raspberry/11-fix-wifi
@@ -35,5 +35,5 @@ elif
 ########################################
 
 if [[ -f "$NM_STATE" ]]; then
-    sed -i 's/^WirelessEnabled=.*/WirelessEnabled=true/' "$NM_STATE"
+    sed -i 's/^WirelessEnabled=.*/WirelessEnabled=true/g' "$NM_STATE"
 fi


### PR DESCRIPTION
Per default, wifi is blocked and disabled on rpi os lite. This PR enable it per default, that headless_nm can use it.