### PR TITLE
fix: fix parsing array to copy special modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
           fi
 
           # Convert JSON array to bash array
-          MODULES=$(echo '${{ toJson(matrix.special_modules) }}' | jq -r '.[]')
+          readarray -t MODULES < <(echo '${{ toJson(matrix.special_modules) }}' | jq -r '.[]')
 
           for module in "${MODULES[@]}"; do
             echo "Copying module: ${module}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,7 @@ jobs:
           fi
 
           # Convert JSON array to bash array
-          MODULES=$(echo '${{ toJson(matrix.special_modules) }}' | jq -r '.[]')
+          readarray -t MODULES < <(echo '${{ toJson(matrix.special_modules) }}' | jq -r '.[]')
 
           for module in "${MODULES[@]}"; do
             echo "Copying module: ${module}"


### PR DESCRIPTION
This PR fix the parsing of the array to copy the special modules in the build and release workflow