### PR TITLE
feat: add CANBUS support

### DIFF
--- a/modules/generic/32-canbus
+++ b/modules/generic/32-canbus
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+#########################################################
+# CANBUS Module                                         #
+# Implemented based on this guide:                      #
+# https://canbus.esoterical.online/Getting_Started.html #
+#########################################################
+
 set -xe
 export LC_ALL=C
 

--- a/modules/generic/32-canbus
+++ b/modules/generic/32-canbus
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -xe
+export LC_ALL=C
+
+########################################
+# Functions and Basic Configuration    #
+########################################
+
+# Load common functions and set up cleanup trap
+source /common.sh
+install_cleanup_trap
+
+# Load additional configuration (e.g., BASE_USER)
+source /files/00-config
+
+########################################
+# Enable systemd-networkd Service      #
+########################################
+
+systemctl_if_exists enable systemd-networkd.service
+
+########################################
+# Disable systemd-networkd-wait-online #
+# to start the CANBUS earlier          #
+########################################
+
+systemctl_if_exists disable systemd-networkd-wait-online.service
+
+########################################
+# Copy config file & udev rules        #
+########################################
+
+cp /files/canbus/10-can.rules /etc/udev/rules.d/
+cp /files/canbus/25-can.network /etc/systemd/network/

--- a/modules/generic/files/canbus/10-can.rules
+++ b/modules/generic/files/canbus/10-can.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="net", ACTION=="change|add", KERNEL=="can*"  ATTR{tx_queue_len}="128"

--- a/modules/generic/files/canbus/25-can.network
+++ b/modules/generic/files/canbus/25-can.network
@@ -1,0 +1,9 @@
+[Match]
+Name=can*
+
+[CAN]
+BitRate=1M
+RestartSec=0.1s
+
+[Link]
+RequiredForOnline=no


### PR DESCRIPTION
This PR adds the CANBUS support per default on every image. It adds the CANBUS settings like this guide: https://canbus.esoterical.online/Getting_Started.html#network-service-can-speeds-and-transmit-queue-length

A big thx to @Esoterical for this very good guide!