### PR TITLE
Fix: prevent upgrade failure by forcing existing config retention

### DIFF
--- a/modules/generic/00-upgrade
+++ b/modules/generic/00-upgrade
@@ -32,7 +32,7 @@ fi
 # Execute upgrade                      #
 ########################################
 
-apt-get -y upgrade
+apt-get -y -o Dpkg::Options::="--force-confold" upgrade
 
 ########################################
 # Cleanup                              #


### PR DESCRIPTION
During apt-get upgrade, the initramfs.conf prompt can cause interactive blocking or failure in noninteractive scripts.

This fix adds --force-confold to apt-get upgrade to prevent the prompt from halting the upgrade process.

Tested on Raspberry Pi OS (Debian 12).

