### PR TITLE
fix(Canboot): Removed `RestartSec=0.1s` from the 25-can.network config.

### DIFF
--- a/modules/generic/files/canbus/25-can.network
+++ b/modules/generic/files/canbus/25-can.network
@@ -3,7 +3,6 @@ Name=can*
 
 [CAN]
 BitRate=1M
-RestartSec=0.1s
 
 [Link]
 RequiredForOnline=no


### PR DESCRIPTION
This option seems to be causing problems for 6.12.47 based raspiOS. I removed it, because Esotherical removed it also from his guide.

https://github.com/Esoterical/voron_canbus/commit/0d7db1ac5db5969a3223fe8982987d01e7f48800